### PR TITLE
RNG: Fix a transcription error

### DIFF
--- a/src/Rand.cpp
+++ b/src/Rand.cpp
@@ -74,11 +74,12 @@ void setall(long iseed1, long iseed2)
 	 Sets the initial seed of generator 1 to ISEED1 and ISEED2. The
 	 initial seeds of the other generators are set accordingly, and
 	 all generators states are set to these seeds.
-	 This is a transcription from Pascal to Fortran of routine
+	 This is a transcription from Pascal to C++ of routine
 	 Set_Initial_Seed from the paper
 	 L'Ecuyer, P. and Cote, S. "Implementing a Random Number Package
 	 with Splitting Facilities." ACM Transactions on Mathematical
 	 Software, 17:98-111 (1991)
+	 https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.149.9439
 							  Arguments
 	 iseed1 -> First of two integer seeds
 	 iseed2 -> Second of two integer seeds

--- a/src/Rand.h
+++ b/src/Rand.h
@@ -7,7 +7,7 @@
 #define Xa1 40014
 #define Xa2 40692
 #define Xa1vw 2082007225
-#define Xa2vw 84306273
+#define Xa2vw 784306273
 
 /* RANDLIB global variables */
 extern int **SamplingQueue;


### PR DESCRIPTION
The PDF of the paper says 784306273, but we had 84306273.

Wolfram alpha confirms that
```
    40692 ^ (2 ^ 50) mod 2147483399 == 784306273
```
which gives me confidence that this is an error in our code, not the PDF.