### PR TITLE
Stop artifact uploads

### DIFF
--- a/.github/workflows/linux_distribution_check.yml
+++ b/.github/workflows/linux_distribution_check.yml
@@ -20,10 +20,6 @@ jobs:
         pwd
         ls -l
         ./regressiontest_UK_100th.py
-    - uses: actions/upload-artifact@v1
-      with:
-        name: regressiontest_UK_100th-generated-xls
-        path: tests/regressiontest_UK_100th
 
   test-in-container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stop artifact uploads as they are causing CI to be red (because we have reached quota limits).  Will re-enable when limits are extended.