### PR TITLE
Guard uses of mcell_adunits[i] as array indices

### DIFF
--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -967,7 +967,10 @@ void SetupPopulation(char* DensityFile, char* SchoolFile, char* RegDemogFile)
 		for (i = 0; i < P.NMC; i++)
 		{
 			if (mcell_num[i] > 0)
+      {
+				if (mcell_adunits[l] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing PopByAdunit)\n", l);
 				mcell_dens[i] *= P.PopByAdunit[mcell_adunits[i]][1] / (1e-10 + P.PopByAdunit[mcell_adunits[i]][0]);
+      }
 			maxd += mcell_dens[i];
 		}
 		t = 0;
@@ -986,6 +989,7 @@ void SetupPopulation(char* DensityFile, char* SchoolFile, char* RegDemogFile)
 		m += (Mcells[i].n = (int)ignbin_mt((long)(P.N - m), s, 0));
 		t -= mcell_dens[i] / maxd;
 		if (Mcells[i].n > 0) P.NMCP++;
+    if (mcell_adunits[l] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", l);
 		AdUnits[mcell_adunits[i]].n += Mcells[i].n;
 	}
 	Mcells[P.NMC - 1].n = P.N - m;


### PR DESCRIPTION
mcell_adunits[i] are all initialised to -1.  Later on the values are
updated, and then used to index into other arrays.  However, there is
no check that the index has been set to something other than -1, and so
there may be out of bounds accesses.  This shouldn't happen based on
other conditions - but is not always statically determinable.

This commit adds some checks to ensure that we don't do an out of bounds
access.

@dlaydon , @gnedjati : This does not change the output of the code at all - except for aborting when we try to access an array out of bounds (which we shouldn't be doing anyway).

Resolves #21 