### PR TITLE
Fix out of bounds accesses when mcell_adunits[i] == -1

### DIFF
--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -988,9 +988,11 @@ void SetupPopulation(char* DensityFile, char* SchoolFile, char* RegDemogFile)
 		if (s > 1.0) s = 1.0;
 		m += (Mcells[i].n = (int)ignbin_mt((long)(P.N - m), s, 0));
 		t -= mcell_dens[i] / maxd;
-		if (Mcells[i].n > 0) P.NMCP++;
-    if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
-		AdUnits[mcell_adunits[i]].n += Mcells[i].n;
+		if (Mcells[i].n > 0) {
+      P.NMCP++;
+      if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
+	  	AdUnits[mcell_adunits[i]].n += Mcells[i].n;
+    }
 	}
 	Mcells[P.NMC - 1].n = P.N - m;
 	if (Mcells[P.NMC - 1].n > 0) P.NMCP++;


### PR DESCRIPTION
This is my second attempt at this!

mcell_adunits[i] is -1 in some circumstances when used as an array index.

The fix is to condition the access to AdUnits on Mcells[i].n > 0, at
which point mcell_adunits[i] should be >= 0.

This does not change behaviour as I contend that:

mcell_adunits[i] == -1 iff Mcells[i].n == 0

Both indicate that there is no population in an mcell.

This is also why this didn't produce any issues previously because when
mcell_adunits[i] was -1 Mcells[i].n was 0 and so the out of bounds write
did not change the value.

@dlaydon, @gnedjati: I think this doesn't change any behaviour but can you take a look please.

Resolves #21 