### PR TITLE
Add default school holidays to admin files

### DIFF
--- a/data/admin_units/Alaska_admin.txt
+++ b/data/admin_units/Alaska_admin.txt
@@ -134,20 +134,20 @@ Alaska
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+44	65	170	353	408	429	534	717	
 
 
 [Holiday durations]
-7 14  7 42
+11	8	83	17	11	8	83	17	
 
 ===================================
 

--- a/data/admin_units/Albania_admin.txt
+++ b/data/admin_units/Albania_admin.txt
@@ -151,14 +151,14 @@ Berat	Dibër	Durrës	Elbasan	Fier	Gjirokastër	Korçë	Kukës	Lezhë	Shkodër	Tiranë	Vlo
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+110	163	355	474	527	719	
 
 
 [Holiday durations]
-7 14  7 42
+7	86	14	7	86	14	
 
 ===================================
 

--- a/data/admin_units/American_Samoa_admin.txt
+++ b/data/admin_units/American_Samoa_admin.txt
@@ -134,20 +134,20 @@ American_Samoa
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+93	177	261	345	457	541	625	709	
 
 
 [Holiday durations]
-7 14  7 42
+15	17	16	43	15	17	16	43	
 
 ===================================
 

--- a/data/admin_units/Austria_admin.txt
+++ b/data/admin_units/Austria_admin.txt
@@ -148,14 +148,14 @@ Burgenland	Kärnten	Niederösterreich	Oberösterreich	Salzburg	Steiermark	Tirol	Vor
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+41	102	182	356	405	466	546	720	
 
 
 [Holiday durations]
-7 14  7 42
+7	11	66	14	7	11	66	14	
 
 ===================================
 

--- a/data/admin_units/Belarus_admin.txt
+++ b/data/admin_units/Belarus_admin.txt
@@ -145,14 +145,14 @@ Brest	Homyel'	Hrodna	Mahilyow	Minsk	Vitsyebsk
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+20	107	172	384	471	536	
 
 
 [Holiday durations]
-7 14  7 42
+15	6	71	15	6	71	
 
 ===================================
 

--- a/data/admin_units/Belgium_admin.txt
+++ b/data/admin_units/Belgium_admin.txt
@@ -142,14 +142,14 @@ Bruxelles	Vlaanderen	Wallonie
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+62	97	181	301	357	426	461	545	665	721	
 
 
 [Holiday durations]
-7 14  7 42
+7	15	61	7	12	7	15	61	7	12	
 
 ===================================
 

--- a/data/admin_units/Bosnia_and_Herzegovina_admin.txt
+++ b/data/admin_units/Bosnia_and_Herzegovina_admin.txt
@@ -142,14 +142,14 @@ Br?ko	Federacija_Bosna_i_Hercegovina	Repuplika_Srpska
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+1	88	170	365	452	534	
 
 
 [Holiday durations]
-7 14  7 42
+25	8	72	25	8	72	
 
 ===================================
 

--- a/data/admin_units/Bulgaria_admin.txt
+++ b/data/admin_units/Bulgaria_admin.txt
@@ -167,14 +167,14 @@ Blagoevgrad	Burgas	Dobrich	Gabrovo	Grad_Sofiya	Haskovo	Kardzhali	Kyustendil	Love
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+88	164	355	452	528	719	
 
 
 [Holiday durations]
-7 14  7 42
+8	91	10	8	91	10	
 
 ===================================
 

--- a/data/admin_units/Canada_admin.txt
+++ b/data/admin_units/Canada_admin.txt
@@ -152,14 +152,14 @@ Alberta	British_Columbia	Manitoba	New_Brunswick	Newfoundland_and_Labrador	Northw
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+74	176	356	438	540	720	
 
 
 [Holiday durations]
-7 14  7 42
+5	90	10	5	90	10	
 
 ===================================
 

--- a/data/admin_units/Croatia_admin.txt
+++ b/data/admin_units/Croatia_admin.txt
@@ -160,14 +160,14 @@ Bjelovarska-Bilogorska	Brodsko-Posavska	Dubrovacko-Neretvanska	Grad_Zagreb	Istar
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+107	164	357	471	528	721	
 
 
 [Holiday durations]
-7 14  7 42
+9	80	17	9	80	17	
 
 ===================================
 

--- a/data/admin_units/Czech_Republic_admin.txt
+++ b/data/admin_units/Czech_Republic_admin.txt
@@ -153,14 +153,14 @@ Jiho?eský	Jihomoravský	Karlovarský	Kraj_Vyso?ina	Královéhradecký	Liberecký	Morav
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+107	179	355	471	543	719	
 
 
 [Holiday durations]
-7 14  7 42
+5	65	10	5	65	10	
 
 ===================================
 

--- a/data/admin_units/Denmark_admin.txt
+++ b/data/admin_units/Denmark_admin.txt
@@ -144,14 +144,14 @@ Hovedstaden	Midtjylland	Nordjylland	Sjælland	Syddanmark
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+41	104	179	287	357	405	468	543	651	721	
 
 
 [Holiday durations]
-7 14  7 42
+7	8	46	7	8	7	8	46	7	8	
 
 ===================================
 

--- a/data/admin_units/Estonia_admin.txt
+++ b/data/admin_units/Estonia_admin.txt
@@ -155,14 +155,14 @@ Harju	Hiiu	Ida-Viru	Järva	Jõgeva	Lääne	Lääne-Viru	Pärnu	Peipsi	Põlva	Rapla	Saare
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+55	111	162	294	357	419	475	526	658	721	
 
 
 [Holiday durations]
-7 14  7 42
+7	7	79	7	12	7	7	79	7	12	
 
 ===================================
 

--- a/data/admin_units/Finland_admin.txt
+++ b/data/admin_units/Finland_admin.txt
@@ -144,14 +144,14 @@ Eastern_Finland	Lapland	Oulu	Southern_Finland	Western_Finland
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+108	151	355	472	515	719	
 
 
 [Holiday durations]
-7 14  7 42
+4	76	17	4	76	17	
 
 ===================================
 

--- a/data/admin_units/France_admin.txt
+++ b/data/admin_units/France_admin.txt
@@ -152,14 +152,14 @@ Auvergne-Rhône-Alpes	Bourgogne-Franche-Comté	Bretagne	Centre-Val_de_Loire	Corse	
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+47	103	187	293	356	411	467	551	657	720	
 
 
 [Holiday durations]
-7 14  7 42
+15	15	56	15	14	15	15	56	15	14	
 
 ===================================
 

--- a/data/admin_units/Germany_admin.txt
+++ b/data/admin_units/Germany_admin.txt
@@ -158,11 +158,11 @@ Baden-Württemberg	Bayern	Berlin	Brandenburg	Bremen	Hamburg	Hessen	Mecklenburg-Vo
 4
 
 [Holiday start times]
-47  96  145 203
+181	354	545	718	
 
 
 [Holiday durations]
-7 14  7 42
+36	14	36	14	
 
 ===================================
 

--- a/data/admin_units/Gibraltar_admin.txt
+++ b/data/admin_units/Gibraltar_admin.txt
@@ -140,14 +140,14 @@ Gibraltar
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+106	180	355	470	544	719	
 
 
 [Holiday durations]
-7 14  7 42
+10	78	14	10	78	14	
 
 ===================================
 

--- a/data/admin_units/Greece_admin.txt
+++ b/data/admin_units/Greece_admin.txt
@@ -147,14 +147,14 @@ Aegean	Athos	Attica	Crete	Epirus_and_Western_Macedonia	Macedonia_and_Thrace	Pelo
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+111	167	357	475	531	721	
 
 
 [Holiday durations]
-7 14  7 42
+12	86	14	12	86	14	
 
 ===================================
 

--- a/data/admin_units/Guam_admin.txt
+++ b/data/admin_units/Guam_admin.txt
@@ -134,20 +134,20 @@ Guam
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+95	148	356	459	512	720	
 
 
 [Holiday durations]
-7 14  7 42
+5	76	10	5	76	10	
 
 ===================================
 

--- a/data/admin_units/Hawaii_admin.txt
+++ b/data/admin_units/Hawaii_admin.txt
@@ -134,20 +134,20 @@ Hawaii
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+44	65	170	353	408	429	534	717	
 
 
 [Holiday durations]
-7 14  7 42
+11	8	83	17	11	8	83	17	
 
 ===================================
 

--- a/data/admin_units/Hungary_admin.txt
+++ b/data/admin_units/Hungary_admin.txt
@@ -159,14 +159,14 @@ Bács-Kiskun	Baranya	Békés	Borsod-Abaúj-Zemplén	Budapest	Csongrád	Fejér	Gyor-Moso
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+107	167	301	357	471	531	665	721	
 
 
 [Holiday durations]
-7 14  7 42
+6	76	5	9	6	76	5	9	
 
 ===================================
 

--- a/data/admin_units/Iceland_admin.txt
+++ b/data/admin_units/Iceland_admin.txt
@@ -147,14 +147,14 @@ Austurland	Hálshreppur	Höfuðborgarsvæði	Norðurland_vestra	Suðurland	Suðurnes	Ves
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+104	154	354	468	518	718	
 
 
 [Holiday durations]
-7 14  7 42
+9	79	13	9	79	13	
 
 ===================================
 

--- a/data/admin_units/Ireland_admin.txt
+++ b/data/admin_units/Ireland_admin.txt
@@ -165,14 +165,14 @@ Carlow	Cavan	Clare	Cork	Donegal	Dublin	Galway	Kerry	Kildare	Kilkenny	Laoighis	Le
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+104	183	301	357	468	547	665	721	
 
 
 [Holiday durations]
-7 14  7 42
+12	64	5	11	12	64	5	11	
 
 ===================================
 

--- a/data/admin_units/Italy_admin.txt
+++ b/data/admin_units/Italy_admin.txt
@@ -159,14 +159,14 @@ Abruzzo	Apulia	Basilicata	Calabria	Campania	Emilia-Romagna	Friuli-Venezia_Giulia
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+109	160	357	473	524	721	
 
 
 [Holiday durations]
-7 14  7 42
+6	93	12	6	93	12	
 
 ===================================
 

--- a/data/admin_units/Latvia_admin.txt
+++ b/data/admin_units/Latvia_admin.txt
@@ -144,14 +144,14 @@ Kurzeme	Latgale	Riga	Vidzeme	Zemgale
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+69	153	294	357	433	517	658	721	
 
 
 [Holiday durations]
-7 14  7 42
+5	89	5	11	5	89	5	11	
 
 ===================================
 

--- a/data/admin_units/Lithuania_admin.txt
+++ b/data/admin_units/Lithuania_admin.txt
@@ -149,14 +149,14 @@ Alytaus	Kauno	Klaipedos	Marijampoles	Panevezio	Šiauliai	Taurages	Telšiai	Utenos	
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+48	112	301	360	412	476	665	724	
 
 
 [Holiday durations]
-7 14  7 42
+5	4	5	5	5	4	5	5	
 
 ===================================
 

--- a/data/admin_units/Luxembourg_admin.txt
+++ b/data/admin_units/Luxembourg_admin.txt
@@ -142,14 +142,14 @@ Diekirch	Grevenmacher	Luxembourg
 0 0 1 1
 
 [Number of holidays]
-4
+12
 
 [Holiday start times]
-47  96  145 203
+46	95	193	219	299	355	410	459	557	583	663	719	
 
 
 [Holiday durations]
-7 14  7 42
+9	17	56	7	9	15	9	17	56	7	9	15	
 
 ===================================
 

--- a/data/admin_units/Macedonia_admin.txt
+++ b/data/admin_units/Macedonia_admin.txt
@@ -224,14 +224,14 @@ Aerodrom	Aracinovo	Berovo	Bitola	Bogdanci	Bogovinje	Bosilovo	Brvenica	Butel	?air
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+115	158	362	479	522	726	
 
 
 [Holiday durations]
-7 14  7 42
+4	84	22	4	84	22	
 
 ===================================
 

--- a/data/admin_units/Malta_admin.txt
+++ b/data/admin_units/Malta_admin.txt
@@ -144,14 +144,14 @@ Malta
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+106	179	357	470	543	721	
 
 
 [Holiday durations]
-7 14  7 42
+9	89	11	9	89	11	
 
 ===================================
 

--- a/data/admin_units/Moldova_admin.txt
+++ b/data/admin_units/Moldova_admin.txt
@@ -176,14 +176,14 @@ Anenii_Noi	B?l?i	Basarabeasca	Bender	Briceni	Cahul	Calarasi	Cantemir	Causeni	Chi
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+32	109	165	299	355	396	473	529	663	719	
 
 
 [Holiday durations]
-7 14  7 42
+9	16	90	9	22	9	16	90	9	22	
 
 ===================================
 

--- a/data/admin_units/Montenegro_admin.txt
+++ b/data/admin_units/Montenegro_admin.txt
@@ -163,11 +163,11 @@ Andrijevica	Bar	Berane	Bijelo_Polje	Budva	Cetinje	Danilovgrad	Herceg_Novi	Kolaši
 4
 
 [Holiday start times]
-47  96  145 203
+163	362	527	726	
 
 
 [Holiday durations]
-7 14  7 42
+80	22	80	22	
 
 ===================================
 

--- a/data/admin_units/Netherlands_admin.txt
+++ b/data/admin_units/Netherlands_admin.txt
@@ -153,14 +153,14 @@ Drenthe	Flevoland	Friesland	Gelderland	Groningen	IJsselmeer	Limburg	Noord-Braban
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+53	200	292	417	564	656	
 
 
 [Holiday durations]
-7 14  7 42
+9	43	9	9	43	9	
 
 ===================================
 

--- a/data/admin_units/Norway_admin.txt
+++ b/data/admin_units/Norway_admin.txt
@@ -158,14 +158,14 @@ Akershus	Ãstfold	Aust-Agder	Buskerud	Finnmark	Hedmark	Hordaland	Møre_og_Romsdal	
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+45	104	170	353	409	468	534	717	
 
 
 [Holiday durations]
-7 14  7 42
+8	9	63	15	8	9	63	15	
 
 ===================================
 

--- a/data/admin_units/Poland_admin.txt
+++ b/data/admin_units/Poland_admin.txt
@@ -155,14 +155,14 @@ Dolno?l?skie	Kujawsko-Pomorskie	?ódzkie	Lubelskie	Lubuskie	Ma?opolskie	Mazowieck
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+20	107	172	384	471	536	
 
 
 [Holiday durations]
-7 14  7 42
+15	6	71	15	6	71	
 
 ===================================
 

--- a/data/admin_units/Portugal_admin.txt
+++ b/data/admin_units/Portugal_admin.txt
@@ -159,14 +159,14 @@ Aveiro	Azores	Beja	Braga	Bragança	Castelo_Branco	Coimbra	Évora	Faro	Guarda	Leiri
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+97	172	350	461	536	714	
 
 
 [Holiday durations]
-7 14  7 42
+15	83	16	15	83	16	
 
 ===================================
 

--- a/data/admin_units/Puerto_Rico_admin.txt
+++ b/data/admin_units/Puerto_Rico_admin.txt
@@ -134,20 +134,20 @@ Puerto_Rico
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+47	95	159	328	356	411	459	523	692	720	
 
 
 [Holiday durations]
-7 14  7 42
+5	5	67	5	15	5	5	67	5	15	
 
 ===================================
 

--- a/data/admin_units/Romania_admin.txt
+++ b/data/admin_units/Romania_admin.txt
@@ -181,14 +181,14 @@ Alba	Arad	Arge?	Bac?u	Bihor	Bistri?a-N?s?ud	Boto?ani	Bra?ov	Br?ila	Bucharest	Buz
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+32	109	165	299	355	396	473	529	663	719	
 
 
 [Holiday durations]
-7 14  7 42
+9	16	90	9	22	9	16	90	9	22	
 
 ===================================
 

--- a/data/admin_units/Russia_admin.txt
+++ b/data/admin_units/Russia_admin.txt
@@ -222,14 +222,14 @@ Adygey	Altay	Amur	Arkhangel'sk	Astrakhan'	Bashkortostan	Belgorod	Bryansk	Buryat	
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+69	153	294	357	433	517	658	721	
 
 
 [Holiday durations]
-7 14  7 42
+5	89	5	11	5	89	5	11	
 
 ===================================
 

--- a/data/admin_units/Serbia_admin.txt
+++ b/data/admin_units/Serbia_admin.txt
@@ -164,14 +164,14 @@ Borski	Brani?evski	Grad_Beograd	Jablani?ki	Južno-Ba?ki	Južno-Banatski	Kolubarski
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+2	119	167	312	366	483	531	676	
 
 
 [Holiday durations]
-7 14  7 42
+6	4	74	4	6	4	74	4	
 
 ===================================
 

--- a/data/admin_units/Slovakia_admin.txt
+++ b/data/admin_units/Slovakia_admin.txt
@@ -147,14 +147,14 @@ Banskobystrickı	Bratislavskı	Košickı	Nitriansky	Prešovskı	Tren?iansky	Trnavskı	
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+55	107	181	357	419	471	545	721	
 
 
 [Holiday durations]
-7 14  7 42
+5	6	62	14	5	6	62	14	
 
 ===================================
 

--- a/data/admin_units/Slovenia_admin.txt
+++ b/data/admin_units/Slovenia_admin.txt
@@ -151,14 +151,14 @@ Gorenjska	Goriška	Jugovzhodna_Slovenija	Koroška	Notranjsko-kraška	Obalno-kraška	
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+51	116	175	301	358	415	480	539	665	722	
 
 
 [Holiday durations]
-7 14  7 42
+7	6	68	7	8	7	6	68	7	8	
 
 ===================================
 

--- a/data/admin_units/Spain_admin.txt
+++ b/data/admin_units/Spain_admin.txt
@@ -157,14 +157,14 @@ Andalucía	Aragón	Cantabria	Castilla-La_Mancha	Castilla_y_León	Cataluña	Ceuta_y_M
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+106	180	355	470	544	719	
 
 
 [Holiday durations]
-7 14  7 42
+10	78	14	10	78	14	
 
 ===================================
 

--- a/data/admin_units/Sweden_admin.txt
+++ b/data/admin_units/Sweden_admin.txt
@@ -160,14 +160,14 @@ Blekinge	Dalarna	Gävleborg	Gotland	Halland	Jämtland	Jönköping	Kalmar	Kronoberg	N
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+106	165	355	470	529	719	
 
 
 [Holiday durations]
-7 14  7 42
+8	71	16	8	71	16	
 
 ===================================
 

--- a/data/admin_units/Switzerland_admin.txt
+++ b/data/admin_units/Switzerland_admin.txt
@@ -168,11 +168,11 @@ Aargau	Appenzell_Ausserrhoden	Appenzell_Innerrhoden	Basel-Landschaft	Basel-Stadt
 4
 
 [Holiday start times]
-47  96  145 203
+181	354	545	718	
 
 
 [Holiday durations]
-7 14  7 42
+36	14	36	14	
 
 ===================================
 

--- a/data/admin_units/Ukraine_admin.txt
+++ b/data/admin_units/Ukraine_admin.txt
@@ -166,14 +166,14 @@ Cherkasy	Chernihiv	Chernivtsi	Crimea	Dnipropetrovs'k	Donets'k	Ivano-Frankivs'k	K
 0 0 1 1
 
 [Number of holidays]
-4
+8
 
 [Holiday start times]
-47  96  145 203
+69	153	294	357	433	517	658	721	
 
 
 [Holiday durations]
-7 14  7 42
+5	89	5	11	5	89	5	11	
 
 ===================================
 

--- a/data/admin_units/United_Kingdom_admin.txt
+++ b/data/admin_units/United_Kingdom_admin.txt
@@ -156,14 +156,14 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 0 0 1 1
 
 [Number of holidays]
-4
+10
 
 [Holiday start times]
-47  96  145 203
+48	97	195	294	353	412	461	559	658	717	
 
 
 [Holiday durations]
-7 14  7 42
+7	15	51	7	15	7	15	51	7	15	
 
 ===================================
 

--- a/data/admin_units/Virgin_Islands_US_admin.txt
+++ b/data/admin_units/Virgin_Islands_US_admin.txt
@@ -134,20 +134,20 @@ Virgin_Islands_US
 
 ===================================
 [Include holidays]
-1
+0
 
 [Proportion of places remaining open during holidays by place type]
 0 0 1 1
 
 [Number of holidays]
-4
+6
 
 [Holiday start times]
-47  96  145 203
+116	168	357	480	532	721	
 
 
 [Holiday durations]
-7 14  7 42
+4	77	10	4	77	10	
 
 ===================================
 


### PR DESCRIPTION
IC issue tracker: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1469

This adds best-guess school holiday figures to all admin units, while leaving them switched off. 

NB: Alaska/Hawaii/Guam/Virgin Islands US/American Samoa/Puerto Rico previously had the holiday param switched on - this PR switches that off.