### PR TITLE
Fixup use of SocDistDurationC

### DIFF
--- a/src/SpatialSim.cpp
+++ b/src/SpatialSim.cpp
@@ -1461,6 +1461,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (!GetInputParameter2(dat, dat2, "Trigger incidence per cell for social distancing", "%i", (void*) & (P.SocDistCellIncThresh), 1, 1, 0)) P.SocDistCellIncThresh = 1000000000;
 	if(!GetInputParameter2(dat, dat2, "Trigger incidence per cell for end of social distancing", "%i", (void*) & (P.SocDistCellIncStopThresh), 1, 1, 0)) P.SocDistCellIncStopThresh = 0;
 	if (!GetInputParameter2(dat, dat2, "Duration of social distancing", "%lf", (void*) & (P.SocDistDuration), 1, 1, 0)) P.SocDistDuration = 7;
+	if (!GetInputParameter2(dat, dat2, "Duration of social distancing after change", "%lf", (void*) & (P.SocDistDuration2), 1, 1, 0)) P.SocDistDuration2 = 7;
 	if (P.DoPlaces)
 	{
 		if (!GetInputParameter2(dat, dat2, "Relative place contact rate given social distancing by place type", "%lf", (void*)P.SocDistPlaceEffect, P.PlaceTypeNum, 1, 0))

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -1126,7 +1126,7 @@ int TreatSweep(double t)
 		tspf = (unsigned short int) ceil(P.TimeStepsPerDay * (t + P.PlaceCloseDelayMean + P.PlaceCloseDuration));
 		tsmf = (unsigned short int) ceil(P.TimeStepsPerDay * (t + P.MoveRestrDuration));
 		tsmb = (unsigned short int) floor(P.TimeStepsPerDay * (t + P.MoveDelayMean));
-		tssdf = (unsigned short int) ceil(P.TimeStepsPerDay * (t + P.SocDistDuration));
+		tssdf = (unsigned short int) ceil(P.TimeStepsPerDay * (t + P.SocDistDurationC));
 		tskwpf = (unsigned short int) ceil(P.TimeStepsPerDay * (t + P.KeyWorkerProphRenewalDuration));
 		nckwp = (int)ceil(P.KeyWorkerProphDuration / P.TreatProphCourseLength);
 


### PR DESCRIPTION
Further fixing of issues noticed by @NeilFerguson on #33.

#33 removed `P.SocDistDurationC` which was highlighted as should be used.

Running `git grep SocDistDurationC $(git rev-list --all) -- src/` over the https://github.com/github/imperial-college-coronavirus repo unfortunately showed no previous commit which had used `SocDistDurationC` except to initialise it.

This PR is my attempt looking at the other `*C` changes to complete the wiring up:

 * Adds reading of `P.SocDistDuration2` parameter (as `[Duration of social distancing after change]`)
 * Replaces the one use of `P.SocDistDuration` in the code with `P.SocDistDurationC` (in Sweep.cpp).

This looks like a correct change to me - but @NeilFerguson can you please confirm.  In particular you mentioned in #40 that the expected change would be in CalcInfSusc.cpp but I couldn't find any appropriate change to make there.