### PR TITLE
Fix issue in age distribution code

### DIFF
--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1173,9 +1173,9 @@ void SetupPopulation(char* DensityFile, char* SchoolFile, char* RegDemogFile)
 				AgeDistCorrB[i][j] /= AgeDistAd[i][j];
 			}
 			// output problematic adjustments (these should be 0.0f)
-			fprintf(stderr, "AgeDistCorrB[%i][0] = %f\n", i, AgeDistCorrB[i][0]); // push down from youngest age group
-			fprintf(stderr, "AgeDistCorrF[%i][NUM_AGE_GROUPS - 1] = %f\n", i, AgeDistCorrF[i][NUM_AGE_GROUPS - 1]); // push up from oldest age group
-			fprintf(stderr, "AgeDistCorrB[%i][NUM_AGE_GROUPS] = %f\n", i, AgeDistCorrB[i][NUM_AGE_GROUPS]); // push down from oldest age group + 1
+			//fprintf(stderr, "AgeDistCorrB[%i][0] = %f\n", i, AgeDistCorrB[i][0]); // push down from youngest age group
+			//fprintf(stderr, "AgeDistCorrF[%i][NUM_AGE_GROUPS - 1] = %f\n", i, AgeDistCorrF[i][NUM_AGE_GROUPS - 1]); // push up from oldest age group
+			//fprintf(stderr, "AgeDistCorrB[%i][NUM_AGE_GROUPS] = %f\n", i, AgeDistCorrB[i][NUM_AGE_GROUPS]); // push down from oldest age group + 1
 		}
 
 		// make age adjustments to population


### PR DESCRIPTION
There was a missing `s` in a `#pragma omp parallel for`.  This caused ages to sometimes be decremented below the lowest age category, eventually causing an error.

I've also added comments that I hope others will find useful, and a check that will catch issues with `age`s much earlier if anything like this happens again.