### PR TITLE
Fix "houshold" typo in parameter names

### DIFF
--- a/data/param_files/p_CI_HQ_DCT.txt
+++ b/data/param_files/p_CI_HQ_DCT.txt
@@ -102,7 +102,7 @@
 [Proportion of places remaining open after closure by place type]
 0	0	0.75	0.75
 
-[Relative houshold contact rate after closure]
+[Relative household contact rate after closure]
 1.5
 
 [Relative spatial contact rate after closure]
@@ -245,7 +245,7 @@
 [Relative place contact rate given social distancing by place type]
 0.25	0.25	0.25	0.25
 
-[Relative houshold contact rate given social distancing]
+[Relative household contact rate given social distancing]
 1.25
 
 [Relative spatial contact rate given social distancing]
@@ -260,7 +260,7 @@
 [Relative place contact rate given enhanced social distancing by place type]
 0.25	0.25	0.25	0.25
 
-[Relative houshold contact rate given enhanced social distancing]
+[Relative household contact rate given enhanced social distancing]
 1
 
 [Relative spatial contact rate given enhanced social distancing]

--- a/data/param_files/p_NoInt.txt
+++ b/data/param_files/p_NoInt.txt
@@ -111,7 +111,7 @@
 [Proportion of places remaining open after closure by place type]	
 0	0	0.25	1
 	
-[Relative houshold contact rate after closure]	
+[Relative household contact rate after closure]	
 2	
 	
 [Relative spatial contact rate after closure]	
@@ -281,7 +281,7 @@
 [Relative place contact rate given social distancing by place type]	
 1	1	0.75	0.75
 	
-[Relative houshold contact rate given social distancing]	
+[Relative household contact rate given social distancing]	
 1.25	
 	
 [Relative spatial contact rate given social distancing]	
@@ -296,7 +296,7 @@
 [Relative place contact rate given enhanced social distancing by place type]	
 0.25	0.25	0.25	0.25
 	
-[Relative houshold contact rate given enhanced social distancing]	
+[Relative household contact rate given enhanced social distancing]	
 1	
 	
 [Relative spatial contact rate given enhanced social distancing]	

--- a/data/param_files/p_PC7_CI_HQ_SD.txt
+++ b/data/param_files/p_PC7_CI_HQ_SD.txt
@@ -111,7 +111,7 @@
 [Proportion of places remaining open after closure by place type]	
 0	0	0.25	1
 	
-[Relative houshold contact rate after closure]	
+[Relative household contact rate after closure]	
 2	
 	
 [Relative spatial contact rate after closure]	
@@ -281,7 +281,7 @@
 [Relative place contact rate given social distancing by place type]	
 1	1	0.75	0.75
 	
-[Relative houshold contact rate given social distancing]	
+[Relative household contact rate given social distancing]	
 1.25	
 	
 [Relative spatial contact rate given social distancing]	
@@ -296,7 +296,7 @@
 [Relative place contact rate given enhanced social distancing by place type]	
 0.25	0.25	0.25	0.25
 	
-[Relative houshold contact rate given enhanced social distancing]	
+[Relative household contact rate given enhanced social distancing]	
 1	
 	
 [Relative spatial contact rate given enhanced social distancing]	

--- a/src/SpatialSim.cpp
+++ b/src/SpatialSim.cpp
@@ -1435,7 +1435,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 			for (i = 0; i < NUM_PLACE_TYPES; i++) P.PlaceCloseEffect[i] = 1;
 	}
 	if (P.DoHouseholds)
-		if (!GetInputParameter2(dat, dat2, "Relative houshold contact rate after closure", "%lf", (void*)& P.PlaceCloseHouseholdRelContact, 1, 1, 0)) P.PlaceCloseHouseholdRelContact = 1;
+		if (!GetInputParameter2(dat, dat2, "Relative household contact rate after closure", "%lf", (void*)& P.PlaceCloseHouseholdRelContact, 1, 1, 0)) P.PlaceCloseHouseholdRelContact = 1;
 	if (!GetInputParameter2(dat, dat2, "Relative spatial contact rate after closure", "%lf", (void*)& P.PlaceCloseSpatialRelContact, 1, 1, 0))
 	{
 		P.PlaceCloseSpatialRelContact = 1;
@@ -1495,10 +1495,10 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	}
 	if (P.DoHouseholds)
 	{
-		if (!GetInputParameter2(dat, dat2, "Relative houshold contact rate given social distancing", "%lf", (void*)& P.SocDistHouseholdEffect, 1, 1, 0)) P.SocDistHouseholdEffect = 1;
-		if (!GetInputParameter2(dat, dat2, "Relative houshold contact rate given enhanced social distancing", "%lf", (void*)& P.ESocDistHouseholdEffect, 1, 1, 0)) P.ESocDistHouseholdEffect = 1;
-		if (!GetInputParameter2(dat, dat2, "Relative houshold contact rate given social distancing  after change", "%lf", (void*)&P.SocDistHouseholdEffect2, 1, 1, 0)) P.SocDistHouseholdEffect2 = P.SocDistHouseholdEffect;
-		if (!GetInputParameter2(dat, dat2, "Relative houshold contact rate given enhanced social distancing after change", "%lf", (void*)&P.ESocDistHouseholdEffect2, 1, 1, 0)) P.ESocDistHouseholdEffect2 = P.ESocDistHouseholdEffect;
+		if (!GetInputParameter2(dat, dat2, "Relative household contact rate given social distancing", "%lf", (void*)& P.SocDistHouseholdEffect, 1, 1, 0)) P.SocDistHouseholdEffect = 1;
+		if (!GetInputParameter2(dat, dat2, "Relative household contact rate given enhanced social distancing", "%lf", (void*)& P.ESocDistHouseholdEffect, 1, 1, 0)) P.ESocDistHouseholdEffect = 1;
+		if (!GetInputParameter2(dat, dat2, "Relative household contact rate given social distancing  after change", "%lf", (void*)&P.SocDistHouseholdEffect2, 1, 1, 0)) P.SocDistHouseholdEffect2 = P.SocDistHouseholdEffect;
+		if (!GetInputParameter2(dat, dat2, "Relative household contact rate given enhanced social distancing after change", "%lf", (void*)&P.ESocDistHouseholdEffect2, 1, 1, 0)) P.ESocDistHouseholdEffect2 = P.ESocDistHouseholdEffect;
 	}
 	if (!GetInputParameter2(dat, dat2, "Relative spatial contact rate given social distancing", "%lf", (void*)& P.SocDistSpatialEffect, 1, 1, 0)) P.SocDistSpatialEffect = 1;
 	if (!GetInputParameter2(dat, dat2, "Relative spatial contact rate given social distancing after change", "%lf", (void*)&P.SocDistSpatialEffect2, 1, 1, 0)) P.SocDistSpatialEffect2 = P.SocDistSpatialEffect;

--- a/tests/p_NoInt.txt
+++ b/tests/p_NoInt.txt
@@ -103,7 +103,7 @@
 [Proportion of places remaining open after closure by place type]
 0	0	0.75	0.75
 
-[Relative houshold contact rate after closure]
+[Relative household contact rate after closure]
 1.5
 
 [Relative spatial contact rate after closure]
@@ -246,7 +246,7 @@
 [Relative place contact rate given social distancing by place type]
 0.5	0.5	0.5	0.5
 
-[Relative houshold contact rate given social distancing]
+[Relative household contact rate given social distancing]
 1
 
 [Relative spatial contact rate given social distancing]
@@ -261,7 +261,7 @@
 [Relative place contact rate given enhanced social distancing by place type]
 0.25	0.25	0.25	0.25
 
-[Relative houshold contact rate given enhanced social distancing]
+[Relative household contact rate given enhanced social distancing]
 1
 
 [Relative spatial contact rate given enhanced social distancing]

--- a/tests/p_PC7_CI_HQ_SDbad.txt
+++ b/tests/p_PC7_CI_HQ_SDbad.txt
@@ -127,7 +127,7 @@
 [Proportion of places remaining open after closure by place type]	
 0	0	0.25	1
 	
-[Relative houshold contact rate after closure]	
+[Relative household contact rate after closure]	
 2	
 	
 [Relative spatial contact rate after closure]	
@@ -273,7 +273,7 @@
 [Relative place contact rate given social distancing by place type]	
 1	1	0.75	0.75
 	
-[Relative houshold contact rate given social distancing]	
+[Relative household contact rate given social distancing]	
 1.25	
 	
 [Relative spatial contact rate given social distancing]	
@@ -288,7 +288,7 @@
 [Relative place contact rate given enhanced social distancing by place type]	
 0.25	0.25	0.25	0.25
 	
-[Relative houshold contact rate given enhanced social distancing]	
+[Relative household contact rate given enhanced social distancing]	
 1	
 	
 [Relative spatial contact rate given enhanced social distancing]	


### PR DESCRIPTION
This might just be unnecessary disruption if people have local parameter files, in which case feel free to just close it. But I thought I'd put it out there now, while the parameter files all need to be changed anyway to take into account the parameters that used to be country-specific #defines.