### PR TITLE
Make the computation of nf more correct

### DIFF
--- a/src/Model.h
+++ b/src/Model.h
@@ -113,6 +113,9 @@ typedef struct POPVAR {
  * 
  * In the function `RecordSample` we transform (copy parts, calculate summary statistics) 
  * of the `POPVAR` state into a time-stamped `RESULTS` structure.
+ *
+ * NOTE: This struct must contain only doubles (and arrays of doubles) for the TSMean
+ * 	     averaging code to work.
  */
 typedef struct RESULTS {
 

--- a/src/SpatialSim.cpp
+++ b/src/SpatialSim.cpp
@@ -4290,8 +4290,8 @@ void RecordInfTypes(void)
 			s += (TimeSeries[n].Rtype[i] /= TimeSeries[n].Rdenom);
 		TimeSeries[n].Rdenom = s;
 	}
-	nf = (sizeof(results) - 3 * sizeof(float*)) / sizeof(double);
-	if (!P.DoAdUnits) nf -= MAX_ADUNITS;
+	nf = sizeof(results) / sizeof(double);
+	if (!P.DoAdUnits) nf -= MAX_ADUNITS; // TODO: This still processes most of the AdUnit arrays; just not the last one
 	fprintf(stderr, "extinct=%i (%i)\n", (int) TimeSeries[P.NumSamples - 1].extinct, P.NumSamples - 1);
 	if (TimeSeries[P.NumSamples - 1].extinct)
 	{
@@ -4311,7 +4311,7 @@ void RecordInfTypes(void)
 			res = (double*)&TimeSeries[n + lc];
 			res_av = (double*)&TSMean[n];
 			res_var = (double*)&TSVar[n];
-			for (i = 1; i < nf; i++)
+			for (i = 1 /* skip over `t` */; i < nf; i++)
 			{
 				res_av[i] += res[i];
 				res_var[i] += res[i] * res[i];


### PR DESCRIPTION
It was subtracting the size of 3 float*s, presumably intended to ignore
```
    float* bmi2, *bmi3, *bmi4;
```
that was removed recently.

It's now subtracting `MAX_ADUNITS` when `DoAdUnits` is disabled, but as there are a number of AdUnit arrays, this isn't going to skip most of them. It should be harmless, though.