### PR TITLE
docker: Add Dockerfile and Actions workflow for publishing Docker images.

### DIFF
--- a/.github/workflows/build_pub_docker.yml
+++ b/.github/workflows/build_pub_docker.yml
@@ -1,0 +1,68 @@
+name: Build & Publish Docker
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: spatialsim
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+            docker build . --target test
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        country: ["UK", "US"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Build image
+        run: docker build . --build-arg COUNTRY=${{ matrix.country }} --file Dockerfile --tag image --target release
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          COUNTRY=$(echo ${{ matrix.country }} | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$IMAGE_ID-$COUNTRY
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Always tag with git sha or version tag
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+          # Use Docker `latest` tag convention for master.
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:stable AS build
+
+ARG COUNTRY=UK
+
+WORKDIR /src
+
+COPY . .
+
+RUN mkdir -p build \
+    && ./ci/install_dependencies.sh
+
+WORKDIR /src/build
+
+RUN cmake -DCOUNTRY=${COUNTRY} ../src \
+    && make
+
+# This allows for building a release without having to potentially re-run the tests.
+FROM debian:stable-slim AS release
+
+# Install runtime dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgomp1 \
+    && apt-get clean -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/build/SpatialSim /usr/bin/.
+COPY data /data/input
+
+ENTRYPOINT ["/usr/bin/SpatialSim"]
+
+FROM build AS test
+
+WORKDIR /src/tests
+
+RUN pwd \
+    && ls -l \
+    && ./regressiontest_UK_100th.py
+
+# This ensures that the default behavior is to run the tests and then create a release
+FROM release


### PR DESCRIPTION
This adds a Dockerfile to the project to enable easier and more uniform
testing. It also adds an Actions workflow to publish the images for
`master` and tags to the GitHub Package Registry so that they can be
more easily consumed by parties that may wish to run the model without
compiling it themselves.