### PR TITLE
Use the same default 'Sampling time' for the UK as for the US

### DIFF
--- a/data/param_files/preUK_R0=2.0.txt
+++ b/data/param_files/preUK_R0=2.0.txt
@@ -59,7 +59,7 @@
 1
 
 [Sampling time]
-150
+720
 
 [Grid size]	
 0.075


### PR DESCRIPTION
In #64, a new preparameters file was introduced for the UK, and the old non-US preparameters file  was moved to the `param_files/Old` directory. The new file sets the `Sampling time` parameter to 150 days instead of 720 days, which is what the old file used, and what the US file still uses.

I think it makes more sense to use 720 days as the default for both the US *and* the UK, because in general, 150 days is not enough to simulate the entire course of the epidemic AFAICT.