### PR TITLE
Shrink a couple of critical sections

### DIFF
--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1256,9 +1256,9 @@ int DoVacc(int ai, unsigned short int ts)
 
 #pragma omp critical (state_cumV)
 		State.cumV++;
-#pragma omp critical (state_cumV_daily)
 		if (P.VaccDosePerDay >= 0)
 		{
+#pragma omp critical (state_cumV_daily)
 			State.cumV_daily++;
 		}
 #pragma omp critical (tot_vacc)
@@ -1290,9 +1290,9 @@ void DoVaccNoDelay(int ai, unsigned short int ts)
 		Hosts[ai].vacc_start_time = ts;
 #pragma omp critical (state_cumVG) //changed to VG
 		State.cumVG++; //changed to VG
-#pragma omp critical (state_cumV_daily)
 		if (P.VaccDosePerDay >= 0)
 		{
+#pragma omp critical (state_cumV_daily)
 			State.cumVG_daily++;
 		}
 #pragma omp critical (tot_vacc)


### PR DESCRIPTION
`P.VaccDosePerDay` isn't modified, so we don't need to be in a critical section to read it. This saves us from needing one at all when it is -1 (the default).