### PR TITLE
Turn COUNTRY_THAILAND into a bool

### DIFF
--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1782,11 +1782,7 @@ void AssignHouseholdAges(int n, int pers, int tn)
 				{
 					a[1] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				}
-#ifdef COUNTRY_THAILAND
 				while ((a[1] > a[0] + P.MaxMFPartnerAgeGap) || (a[1] < a[0] - P.MaxFMPartnerAgeGap) || (a[1] < P.MinAdultAge));
-#else
-				while ((a[1] > a[0] + P.MaxMFPartnerAgeGap) || (a[1] < a[0] - P.MaxFMPartnerAgeGap) || (a[1] < P.MinAdultAge));
-#endif
 			}
 
 		}
@@ -1829,11 +1825,7 @@ void AssignHouseholdAges(int n, int pers, int tn)
 				{
 					a[2] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				}
-#ifdef COUNTRY_THAILAND
 				while ((a[2] >= a[1] + P.MaxMFPartnerAgeGap) || (a[2] < a[1] - P.MaxFMPartnerAgeGap));
-#else
-				while ((a[2] >= a[1] + P.MaxMFPartnerAgeGap) || (a[2] < a[1] - P.MaxFMPartnerAgeGap));
-#endif
 			}
 			else
 			{


### PR DESCRIPTION
For now at least, the value is set based on the `COUNTRY_THAILAND` preprocessor symbol, so the compiler will optimise out all the code that isn't being used, and performance will be unchanged.

But it would now be easy to make it a run-time parameter instead.

Doing it this way also means that the compiler can see all the code, so it is less likely that code changes for UK/US/... will break the Thailand code.

Review will probably be easier if you [ignore whitespace differences](https://github.com/mrc-ide/covid-sim/pull/130/files?w=1) as some code needed to be indented deeper.