### PR TITLE
Remove outdated "copying and distribution prohibited" line

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -1,6 +1,5 @@
 /*
 (c) 2004-13 Neil Ferguson, Imperial College London (neil.ferguson@imperial.ac.uk)
-	All rights reserved. Copying and distribution prohibited without prior permission.
 */
 
 #include <errno.h>


### PR DESCRIPTION
Presumably this is superseded by the GPL license this repo is under, but just to avoid any doubt.