### PR TITLE
Ci love

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.vscode
+out
+**/build*

--- a/.github/workflows/linux_distribution_check.yml
+++ b/.github/workflows/linux_distribution_check.yml
@@ -11,19 +11,14 @@ jobs:
     - name: build
       run: |
         mkdir build && cd build
-        cmake ../src
-        make
-        cd ..
+        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake --build . -- -j$(nproc)
     - name: regression test (UK based)
       run: |
-        cd tests
-        pwd
-        ls -l
-        ./regressiontest_UK_100th.py
+        ctest --tests-regex regressiontest_UK_100th --verbose
     - name: regression test (US based)
       run: |
-        cd "${GITHUB_WORKSPACE}/tests"
-        ./regressiontest_US_based.py
+        ctest --tests-regex regressiontest_US_based --verbose
 
   test-in-container:
     runs-on: ubuntu-latest
@@ -42,16 +37,11 @@ jobs:
     - name: build
       run: |
         mkdir build && cd build
-        cmake ../src
-        make
-        cd ..
-    - name: regression test
+        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake --build . -- -j$(nproc)
+    - name: regression test (UK based)
       run: |
-        cd tests
-        pwd
-        ls -l
-        ./regressiontest_UK_100th.py
+        ctest --tests-regex regressiontest_UK_100th --verbose
     - name: regression test (US based)
       run: |
-        cd "${GITHUB_WORKSPACE}/tests"
-        ./regressiontest_US_based.py
+        ctest --tests-regex regressiontest_US_based --verbose

--- a/.github/workflows/linux_distribution_check.yml
+++ b/.github/workflows/linux_distribution_check.yml
@@ -11,7 +11,7 @@ jobs:
     - name: build
       run: |
         mkdir build && cd build
-        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DPYTHON_EXECUTABLE:FILEPATH:=python3 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
         cmake --build . -- -j$(nproc)
     - name: regression test (UK based)
       run: |
@@ -37,7 +37,7 @@ jobs:
     - name: build
       run: |
         mkdir build && cd build
-        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DPYTHON_EXECUTABLE:FILEPATH:=python3 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
         cmake --build . -- -j$(nproc)
     - name: regression test (UK based)
       run: |

--- a/.github/workflows/macos_distribution_check.yml
+++ b/.github/workflows/macos_distribution_check.yml
@@ -16,16 +16,11 @@ jobs:
     - name: build
       run: |
         mkdir build && cd build
-        cmake ../src
-        make
-        cd ..
+        cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DPYTHON_EXECUTABLE:FILEPATH:=/usr/local/bin/python3 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake --build . -- -j`nproc`
     - name: regression test (UK based)
       run: |
-        cd tests
-        pwd
-        ls -l
-        ./regressiontest_UK_100th.py
+        ctest --tests-regex regressiontest_UK_100th --verbose
     - name: regression test (US based)
       run: |
-        cd "${GITHUB_WORKSPACE}/tests"
-        ./regressiontest_US_based.py
+        ctest --tests-regex regressiontest_US_based --verbose

--- a/.github/workflows/windows_distribution_check.yml
+++ b/.github/workflows/windows_distribution_check.yml
@@ -12,16 +12,11 @@ jobs:
         run: |
           md build
           cd build
-          cmake ..\src
+          cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
           cmake --build .
-          cd ..
       - name: regression test (UK based)
         run: |
-          cd tests
-          python.exe regressiontest_UK_100th.py
-          cd ..
+          ctest --tests-regex regressiontest_UK_100th --verbose
       - name: regression test (US based)
         run: |
-          cd tests
-          python.exe regressiontest_US_based.py
-          cd ..
+          ctest --tests-regex regressiontest_US_based --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+# CMakeLists.txt
+
+# CMake setup
+cmake_minimum_required (VERSION 3.8)
+
+# Set a default build type if none was specified
+set(default_build_type "RelWithDebInfo")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Project initialisation
+project("CovidSim")
+
+option(USE_OPENMP "Compile with OpenMP parallelism enabled" ON)
+option(ENABLE_REGRESSION_TEST "Enables regression testing targets" ON)
+
+# Packages used
+if(USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+endif()
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+
+# CovidSim target
+add_subdirectory(src)
+if(ENABLE_REGRESSION_TEST)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN mkdir -p build \
 
 WORKDIR /src/build
 
-RUN cmake ../src \
-    && make
+RUN cmake -DENABLE_REGRESSION_TEST:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON .. \
+    && cmake --build . -- -j$(nproc)
 
 # This allows for building a release without having to potentially re-run the tests.
 FROM debian:stable-slim AS release
@@ -22,18 +22,16 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /src/build/CovidSim /usr/bin/.
+COPY --from=build /src/build/src/CovidSim /usr/bin/.
 COPY data /data/input
 
 ENTRYPOINT ["/usr/bin/CovidSim"]
 
 FROM build AS test
 
-WORKDIR /src/tests
+WORKDIR /src/build
 
-RUN pwd \
-    && ls -l \
-    && ./regressiontest_UK_100th.py
+RUN ctest --tests-regex regressiontest_UK_100th --verbose
 
 # This ensures that the default behavior is to run the tests and then create a release
 FROM release

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -32,6 +32,7 @@ case "$distro_id" in
         yum -y install epel-release
         yum -y install cmake3 make gcc-c++
         ln -s /bin/cmake3 /bin/cmake
+        ln -s /bin/ctest3 /bin/ctest
         ;;
 
     'opensuse'|'opensuse-tumbleweed')

--- a/data/run_sample.py
+++ b/data/run_sample.py
@@ -44,7 +44,7 @@ def parse_args():
     data_dir = script_path
     param_dir = os.path.join(script_path, "param_files")
     output_dir = os.getcwd()
-    src_dir = os.path.join(data_dir, os.pardir, "src")
+    root_dir = os.path.join(data_dir, os.pardir)
 
     parser.add_argument(
             "country",
@@ -63,7 +63,7 @@ def parse_args():
     parser.add_argument(
             "--srcdir",
             help="Directory with source in - needed if --covidsim isn't specified",
-            default=src_dir)
+            default=root_dir)
     parser.add_argument(
             "--outputdir",
             help="Directory to store output data",
@@ -102,9 +102,9 @@ else:
 
     # Where the exe ends up depends on the OS.
     if os.name == 'nt':
-        exe = os.path.join(build_dir, "Debug", "CovidSim.exe")
+        exe = os.path.join(build_dir, "src", "Debug", "CovidSim.exe")
     else:
-        exe = os.path.join(build_dir, "CovidSim")
+        exe = os.path.join(build_dir, "src", "CovidSim")
 
     os.chdir(cwd)
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -21,12 +21,13 @@ This will create project files inside the `build` directory that can be opened i
 # Building directly with CMake in Visual Studio 2019
 Visual Studio 2019 supports using CMake to manage the build directly by selecting File -> Open -> Cmake... and opening `src/CMakeLists.txt`. Then Visual Studio's normal build shortcuts will update the CMake configuration as well as building the project.
 
-CMake options are configured using the `CMakeSettings.json` file, which Visual Studio will generate when `CMakeLists.txt` is opened.
+CMake options are configured using the `CMakeSettings.json` file, which Visual Studio will generate when `CMakeLists.txt` is opened. If a python3 interpreter is not available in your PATH, you may wish to either disable regression tests (they are enabled by default), or provide the path to a valid python3 interpreter.
 
 # Build options
 Additional configuration variables can be provided in the `cmake` invocation.
 
 - `USE_OPENMP` determines whether the model is compiled with parallelization using OpenMP. This option defaults to on, but can be disabled by passing `-DUSE_OPENMP=OFF`. The simulation is designed to be run on multi-core systems. Performance improvements are approximately linear up to 24 to 32 cores, depending on memory performance.
+- `ENABLE_REGRESSION_TEST` enables running the regression tests via ctest, which requires a working python3 interpreter to be available. A python interpreter can be specified by passing `-DPYTHON_EXECUTABLE:FILEPATH=<PATH_TO_PYTHON>`. Regression tests can be disabled by passing `-DENABLE_REGRESSION_TEST:BOOL=OFF`. By default, regression tests are enabled, and can be invoked by simply running `make test` or running `ctest` on the command-line manually.
 
 For Makefile builds, a build type can be specified by passing `-DCMAKE_BUILD_TYPE=Debug`, `-DCMAKE_BUILD_TYPE=MinSizeRel`, `-DCMAKE_BUILD_TYPE=Release`, or `-DCMAKE_BUILD_TYPE=RelWithDebInfo`. By default, Makefile builds will use `RelWithDebInfo`.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,33 +1,3 @@
-# CMakeLists.txt
-
-# CMake setup
-cmake_minimum_required (VERSION 3.8)
-
-# Set a default build type if none was specified
-set(default_build_type "RelWithDebInfo")
-
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
-
-# Project initialisation
-project("CovidSim")
-
-option(USE_OPENMP "Compile with OpenMP parallelism enabled" ON)
-
-# Packages used
-if(USE_OPENMP)
-  find_package(OpenMP REQUIRED)
-endif()
-
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 11)
-
 # CovidSim target
 add_executable(CovidSim CovidSim.cpp CovidSim.h binio.cpp binio.h Rand.cpp Rand.h Constants.h Country.h MachineDefines.h Error.cpp Error.h Dist.cpp Dist.h Kernels.cpp Kernels.h Bitmap.cpp Bitmap.h Model.h Param.h SetupModel.cpp SetupModel.h SharedFuncs.h ModelMacros.h InfStat.h CalcInfSusc.cpp CalcInfSusc.h Sweep.cpp Sweep.h Update.cpp Update.h)
 target_include_directories(CovidSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+find_package(PythonInterp)
+
+if (${PYTHONINTERP_FOUND} AND ${PYTHON_VERSION_MAJOR} LESS 3)
+    message (FATAL_ERROR "Python interpreter must be version 3 or higher, please supply a valid interpreter via the PYTHON_EXECUTABLE variable")
+endif ()
+
+if (${PYTHONINTERP_FOUND})
+    add_test(
+        NAME
+            regressiontest_UK_100th
+        COMMAND
+            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/regressiontest_UK_100th.py
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_LIST_DIR}
+    )
+    set_tests_properties (
+        regressiontest_UK_100th
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "SUCCESS"
+            FAIL_REGULAR_EXPRESSION "FAILURE;TEST FAILED"
+    )
+    add_test(
+        NAME
+            regressiontest_US_based
+        COMMAND
+            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/regressiontest_US_based.py
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_LIST_DIR}
+    )
+    set_tests_properties (
+        regressiontest_US_based
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "SUCCESS"
+            FAIL_REGULAR_EXPRESSION "FAILURE;TEST FAILED"
+    )
+endif ()

--- a/tests/regressiontest_UK_100th.py
+++ b/tests/regressiontest_UK_100th.py
@@ -90,13 +90,13 @@ updir1 = os.pardir + os.sep
 shutil.rmtree(testdir, True)
 os.mkdir(testdir)
 os.chdir(testdir)
-subprocess.check_call(['cmake', '-DCMAKE_CXX_FLAGS=-DNO_WIN32_BM', updir2 + 'src'])
+subprocess.check_call(['cmake', '-DCMAKE_CXX_FLAGS=-DNO_WIN32_BM', updir2])
 subprocess.check_call(['cmake', '--build', '.'])
 
 if os.name == 'nt':
-    covidsim_exe = os.getcwd() + os.sep + 'Debug\CovidSim.exe'
+    covidsim_exe = os.path.join(os.getcwd(), "src", "Debug", "CovidSim.exe")
 else:
-    covidsim_exe = os.getcwd() + os.sep + 'CovidSim'
+    covidsim_exe = os.path.join(os.getcwd(), "src", "CovidSim")
 print(covidsim_exe)
 
 # Population density file in gziped form, text file, and binary file as

--- a/tests/regressiontest_US_based.py
+++ b/tests/regressiontest_US_based.py
@@ -85,19 +85,19 @@ if len(sys.argv) > 1 and sys.argv[1] == '--accept':
 script_dir = os.path.dirname(os.path.realpath(__file__))
 input_dir = os.path.join(script_dir, 'us-input')
 output_dir = os.path.join(script_dir, 'us-output')
-src_dir = os.path.join(script_dir, os.pardir, 'src')
+root_dir = os.path.join(script_dir, os.pardir)
 data_dir = os.path.join(script_dir, os.pardir, 'data')
 
 shutil.rmtree(output_dir, ignore_errors=True)
 os.makedirs(output_dir, exist_ok=False)
 os.chdir(output_dir)
-subprocess.run(['cmake', src_dir])
+subprocess.run(['cmake', root_dir])
 subprocess.run(['cmake', '--build', '.'])
 
 if os.name == 'nt':
-    covidsim_exe = os.getcwd() + os.sep + 'Debug\CovidSim.exe'
+    covidsim_exe = os.path.join(os.getcwd(), "src", "Debug", "CovidSim.exe")
 else:
-    covidsim_exe = os.getcwd() + os.sep + 'CovidSim'
+    covidsim_exe = os.path.join(os.getcwd(), "src", "CovidSim")
 print(covidsim_exe)
 
 # Population density file in gziped form, text file, and binary file as


### PR DESCRIPTION
This pull request integrates the regression tests with ctest, as referenced in ticket #75 

Regression tests are run via ctest, and can be disabled by passing -DENABLE_REGRESSION_TESTS:BOOL=OFF when configuring cmake, the default is enabled.

This changeset also includes a dockerignore file, which makes building the Docker images a good bit faster.