### PR TITLE
Remove unused param field CaseIsolationTimeStart

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2759,7 +2759,6 @@ void InitModel(int run) // passing run number so we can save run number in the i
 	P.PlaceCloseTimeStart2 = 2e10;
 	P.SocDistTimeStart = 1e10;
 	P.AirportCloseTimeStart = 1e10;
-	P.CaseIsolationTimeStart = 1e10;
 	//P.DigitalContactTracingTimeStart = 1e10;
 	P.HQuarantineTimeStart = 1e10;
 	P.KeyWorkerProphTimeStart = 1e10;

--- a/src/Param.h
+++ b/src/Param.h
@@ -136,7 +136,7 @@ typedef struct PARAM {
 	double MoveDelayMean, MoveRestrEffect, MoveRestrDuration, MoveRestrTimeStart;
 	double AirportCloseTimeStart, AirportCloseDuration, AirportCloseEffectiveness;
 
-	double CaseIsolationTimeStart, CaseIsolationDuration, CaseIsolationEffectiveness, CaseIsolationHouseEffectiveness;
+	double CaseIsolationDuration, CaseIsolationEffectiveness, CaseIsolationHouseEffectiveness;
 	double CaseIsolationDelay, CaseIsolationPolicyDuration, CaseIsolationProp;
 
 	double HQuarantineTimeStart, HQuarantineHouseDelay, HQuarantineHouseDuration, HQuarantinePolicyDuration, HQuarantinePropIndivCompliant;


### PR DESCRIPTION
There is still a field in adminunit with the same name, which is used.