### PR TITLE
Make BMP format selection a command line option

### DIFF
--- a/docs/inputs-and-outputs.md
+++ b/docs/inputs-and-outputs.md
@@ -70,6 +70,7 @@ Explanation of additional arguments:
 - `[/s:USschools.txt]` School information for a specific geography (currently only used for US).
 - `[/R:1.1]`. Spcifies the reproduction number (`R0`), as a multiplier of 2. `R0`, for a disease is the number of secondary cases in susceptibles per infected case. These commandline parameter is read into `P.R0scaling` which scales the `R0` parameter (specified in the parameter file), which is useful when we want repeated that *only* vary `R0`). For COVID-19, `/R:1.4` to `/R:1.6` is suitable.
 - `/CLP1:100000`, `/CLP2:0` etc. are special parameters that interact with wildcards `#1`, `#2` etc. in the intervention parameter file (and less often the pre-parameter file). Wildcard `#n` is replaced by the value of `CLPn`. This is useful to vary parts of parameter files at run-time (e.g. to undertake sensitivity analysis) without needing to generate entirely new parameter files.
+- `[/BM:format]`.  Specifies the output bitmap format.  Valid choices are `BMP`, or (when available) `PNG`.  Default is `PNG` if available, otherwise `BMP`.
 
 ## Input files
 

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -15,7 +15,7 @@
 
 #ifdef WIN32_BM
 //HAVI avi;
-ULONG_PTR m_gdiplusToken;
+static ULONG_PTR m_gdiplusToken;
 static HBITMAP bmpdib;
 static CLSID  encoderClsid;
 #endif
@@ -302,3 +302,9 @@ void InitBMHead()
 #endif
 }
 
+void Bitmap_Finalise()
+{
+#ifdef _WIN32
+  Gdiplus::GdiplusShutdown(m_gdiplusToken);
+#endif
+}

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -13,7 +13,7 @@
 //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** 
 //// **** BITMAP stuff. 
 
-#ifdef WIN32_BM
+#ifdef _WIN32
 //HAVI avi;
 static ULONG_PTR m_gdiplusToken;
 static HBITMAP bmpdib;
@@ -147,66 +147,76 @@ void OutputBitmap(int tp)
 		sprintf(OutF, "%s.ge" DIRECTORY_SEPARATOR "Max.%s", OutFile, OutBaseName);
 	}
 
-#ifdef IMAGE_MAGICK
-	FILE* dat;
-	using namespace Magick;
-	fprintf(stderr, "\noutputing ImageMagick stuff");
-	sprintf(buf, "%s.bmp", OutF);
-	if (!(dat = fopen(buf, "wb"))) ERR_CRITICAL("Unable to open bitmap file\n");
-	fprintf(dat, "BM");
-	//fwrite_big((void *) &bmf,sizeof(unsigned char),(sizeof(bitmap_header)/sizeof(unsigned char))+bmh->imagesize,dat);
-	fwrite_big((void*)bmf, sizeof(bitmap_header), 1, dat);
-	for (int i = 0; i < bmh->imagesize; i++) fputc(bmPixels[i], dat);
-	fclose(dat);
-	Image bmap(buf);
-	sprintf(buf, "%s.%d.png", OutF, j);
-	ColorRGB white(1.0, 1.0, 1.0);
-	bmap.transparent(white);
-	bmap.write(buf);
-#elif defined(WIN32_BM)	
-	//Windows specific bitmap manipulation code - could be recoded using LIBGD or another unix graphics library
-	using namespace Gdiplus;
-
-	wchar_t wbuf[1024];
-	size_t a;
-
-	//Add new bitmap to AVI
-	//if ((P.OutputBitmap == 1) && (tp == 0)) AddAviFrame(avi, bmpdib, (unsigned char*)(&bmh->palette[0][0]));
-
-	//This transfers HBITMAP to GDI+ Bitmap object
-	Bitmap* gdip_bmp = Bitmap::FromHBITMAP(bmpdib, NULL);
-	//Now change White in palette (first entry) to be transparent
-	if ((cn1 == 1) && (tp == 0))
+	if (P.BitmapFormat == BF_PNG)
 	{
-		static UINT palsize;
-		static ColorPalette* palette;
-		palsize = gdip_bmp->GetPaletteSize();
-		palette = (ColorPalette*)malloc(palsize);
-		if (!palette) ERR_CRITICAL("Unable to allocate palette memory\n");
-		(void)gdip_bmp->GetPalette(palette, palsize);
-		palette->Flags = PaletteFlagsHasAlpha;
-		palette->Entries[0] = 0x00ffffff; // Transparent white 
-		gdip_bmp->SetPalette(palette);
-	}
-	//Now save as png
-	sprintf(buf, "%s.%05i.png", OutF, j + 1); //sprintf(buf,"%s.ge" DIRECTORY_SEPARATOR "%s.%05i.png",OutFileBase,OutF,j+1);
-	mbstowcs_s(&a, wbuf, strlen(buf) + 1, buf, _TRUNCATE);
-	gdip_bmp->Save(wbuf, &encoderClsid, NULL);
-	delete gdip_bmp;
+#ifdef IMAGE_MAGICK
+	  FILE* dat;
+	  using namespace Magick;
+	  fprintf(stderr, "\noutputing ImageMagick stuff");
+	  sprintf(buf, "%s.bmp", OutF);
+	  if (!(dat = fopen(buf, "wb"))) ERR_CRITICAL("Unable to open bitmap file\n");
+	  fprintf(dat, "BM");
+	  //fwrite_big((void *) &bmf,sizeof(unsigned char),(sizeof(bitmap_header)/sizeof(unsigned char))+bmh->imagesize,dat);
+	  fwrite_big((void*)bmf, sizeof(bitmap_header), 1, dat);
+	  for (int i = 0; i < bmh->imagesize; i++) fputc(bmPixels[i], dat);
+	  fclose(dat);
+	  Image bmap(buf);
+	  sprintf(buf, "%s.%d.png", OutF, j);
+	  ColorRGB white(1.0, 1.0, 1.0);
+	  bmap.transparent(white);
+	  bmap.write(buf);
+#elif defined(_WIN32)	
+	  //Windows specific bitmap manipulation code - could be recoded using LIBGD or another unix graphics library
+	  using namespace Gdiplus;
+
+	  wchar_t wbuf[1024];
+	  size_t a;
+
+	  //Add new bitmap to AVI
+	  //if ((P.OutputBitmap == 1) && (tp == 0)) AddAviFrame(avi, bmpdib, (unsigned char*)(&bmh->palette[0][0]));
+
+	  //This transfers HBITMAP to GDI+ Bitmap object
+	  Bitmap* gdip_bmp = Bitmap::FromHBITMAP(bmpdib, NULL);
+	  //Now change White in palette (first entry) to be transparent
+	  if ((cn1 == 1) && (tp == 0))
+	  {
+		  static UINT palsize;
+		  static ColorPalette* palette;
+		  palsize = gdip_bmp->GetPaletteSize();
+		  palette = (ColorPalette*)malloc(palsize);
+		  if (!palette) ERR_CRITICAL("Unable to allocate palette memory\n");
+		  (void)gdip_bmp->GetPalette(palette, palsize);
+		  palette->Flags = PaletteFlagsHasAlpha;
+		  palette->Entries[0] = 0x00ffffff; // Transparent white 
+		  gdip_bmp->SetPalette(palette);
+	  }
+	  //Now save as png
+	  sprintf(buf, "%s.%05i.png", OutF, j + 1); //sprintf(buf,"%s.ge" DIRECTORY_SEPARATOR "%s.%05i.png",OutFileBase,OutF,j+1);
+	  mbstowcs_s(&a, wbuf, strlen(buf) + 1, buf, _TRUNCATE);
+	  gdip_bmp->Save(wbuf, &encoderClsid, NULL);
+	  delete gdip_bmp;
 #else
-	sprintf(buf, "%s.%05i.bmp", OutF, j);
-	FILE* dat;
-	if (!(dat = fopen(buf, "wb"))) {
-		char *errMsg = strerror(errno);
-		if (errMsg == nullptr) {
-			ERR_CRITICAL("strerror failed.\n");
-		}
-		ERR_CRITICAL_FMT("Unable to open bitmap file %s (%d): %s\n", buf, errno, errMsg);
-	}
-	fprintf(dat, "BM");
-	fwrite_big((void*)bmf, sizeof(unsigned char), sizeof(bitmap_header) / sizeof(unsigned char) + bmh->imagesize, dat);
-	fclose(dat);
+	  fprintf(stderr, "Do not know how to output PNG\n");
 #endif
+	}
+	else if (P.BitmapFormat == BF_BMP) {
+	  sprintf(buf, "%s.%05i.bmp", OutF, j);
+	  FILE* dat;
+	  if (!(dat = fopen(buf, "wb"))) {
+	    char* errMsg = strerror(errno);
+	    if (errMsg == nullptr) {
+	      ERR_CRITICAL("strerror failed.\n");
+	    }
+	    ERR_CRITICAL_FMT("Unable to open bitmap file %s (%d): %s\n", buf, errno, errMsg);
+	  }
+	  fprintf(dat, "BM");
+	  fwrite_big((void*)bmf, sizeof(unsigned char), sizeof(bitmap_header) / sizeof(unsigned char) + bmh->imagesize, dat);
+	  fclose(dat);
+	}
+	else
+	{
+	  fprintf(stderr, "Unknown Bitmap format: %d\n", (int)P.BitmapFormat);
+	}
 }
 void InitBMHead()
 {
@@ -265,33 +275,34 @@ void InitBMHead()
 	if (!(bmTreated = (int32_t*)malloc(bmh->imagesize * sizeof(int32_t))))
 		ERR_CRITICAL("Unable to allocate storage for bitmap\n");
 
-#ifdef WIN32_BM
-	bmpdib = CreateDIBSection(GetDC(NULL), (BITMAPINFO*)bmp, DIB_RGB_COLORS, (void**)& bmPixels, NULL, NULL);
-	Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-	Gdiplus::GdiplusStartup(&m_gdiplusToken, &gdiplusStartupInput, NULL);
-
-	UINT  num = 0;          // number of image encoders
-	UINT  size = 0;         // size of the image encoder array in bytes
-
-	Gdiplus::ImageCodecInfo* pImageCodecInfo = NULL;
-	Gdiplus::GetImageEncodersSize(&num, &size);
-	if (!(pImageCodecInfo = (Gdiplus::ImageCodecInfo*)(malloc(size))))
-		ERR_CRITICAL("Unable to allocate storage for bitmap\n");
-	Gdiplus::GetImageEncoders(num, size, pImageCodecInfo);
-	for (UINT j = 0; j < num; ++j)
+	if (P.BitmapFormat == BF_PNG)
 	{
-// Visual Studio Analyze incorrectly reports this because it doesn't understand Gdiplus::GetImageEncodersSize()
-// warning C6385: Reading invalid data from 'pImageCodecInfo':  the readable size is 'size' bytes, but '208' bytes may be read.
+#ifdef _WIN32
+	  bmpdib = CreateDIBSection(GetDC(NULL), (BITMAPINFO*)bmp, DIB_RGB_COLORS, (void**)&bmPixels, NULL, NULL);
+	  Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+	  Gdiplus::GdiplusStartup(&m_gdiplusToken, &gdiplusStartupInput, NULL);
+
+	  UINT  num = 0;          // number of image encoders
+	  UINT  size = 0;         // size of the image encoder array in bytes
+
+	  Gdiplus::ImageCodecInfo* pImageCodecInfo = NULL;
+	  Gdiplus::GetImageEncodersSize(&num, &size);
+	  if (!(pImageCodecInfo = (Gdiplus::ImageCodecInfo*)(malloc(size))))
+	    ERR_CRITICAL("Unable to allocate storage for bitmap\n");
+	  Gdiplus::GetImageEncoders(num, size, pImageCodecInfo);
+	  for (UINT j = 0; j < num; ++j) {
+	    // Visual Studio Analyze incorrectly reports this because it doesn't understand Gdiplus::GetImageEncodersSize()
+	    // warning C6385: Reading invalid data from 'pImageCodecInfo':  the readable size is 'size' bytes, but '208' bytes may be read.
 #pragma warning( suppress: 6385 )
-		const WCHAR* type = pImageCodecInfo[j].MimeType;
-		if (wcscmp(type, L"image/png") == 0)
-		{
-			encoderClsid = pImageCodecInfo[j].Clsid;
-			j = num;
-		}
-	}
-	free(pImageCodecInfo);
+	    const WCHAR* type = pImageCodecInfo[j].MimeType;
+	    if (wcscmp(type, L"image/png") == 0) {
+	      encoderClsid = pImageCodecInfo[j].Clsid;
+	      j = num;
+	    }
+	  }
+	  free(pImageCodecInfo);
 #endif
+	}
 
 	char buf[1024+3];
 	sprintf(buf, "%s.ge", OutFileBase);
@@ -304,7 +315,10 @@ void InitBMHead()
 
 void Bitmap_Finalise()
 {
+  if (P.BitmapFormat == BF_PNG)
+  {
 #ifdef _WIN32
-  Gdiplus::GdiplusShutdown(m_gdiplusToken);
+    Gdiplus::GdiplusShutdown(m_gdiplusToken);
 #endif
+  }
 }

--- a/src/Bitmap.h
+++ b/src/Bitmap.h
@@ -9,19 +9,15 @@
 #define DIRECTORY_SEPARATOR "/"
 #else
 #define DIRECTORY_SEPARATOR "\\"
-#ifndef NO_WIN32_BM
-#define WIN32_BM
 #endif
-#endif
+
 #define STRICT
 #ifdef _WIN32
 #define _WIN32_WINNT 0x0400
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#ifdef WIN32_BM
 #include <vfw.h>
 #include <gdiplus.h>
-#endif
 #endif
 #ifdef IMAGE_MAGICK
 #include "Magick++.h"
@@ -45,11 +41,6 @@ typedef struct BITMAP_HEADER {
 
 extern int32_t *bmPopulation, *bmInfected, *bmRecovered, *bmTreated;
 extern bitmap_header* bmh;
-
-#ifdef WIN32_BM
-//DECLARE_HANDLE(HAVI);
-//extern HAVI avi;
-#endif
 
 void CaptureBitmap();
 void OutputBitmap(int);

--- a/src/Bitmap.h
+++ b/src/Bitmap.h
@@ -49,11 +49,12 @@ extern bitmap_header* bmh;
 #ifdef WIN32_BM
 //DECLARE_HANDLE(HAVI);
 //extern HAVI avi;
-extern ULONG_PTR m_gdiplusToken;
 #endif
 
 void CaptureBitmap();
 void OutputBitmap(int);
 void InitBMHead();
+
+void Bitmap_Finalise();
 
 #endif // COVIDSIM_BITMAP_H_INCLUDED_

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -420,10 +420,8 @@ int main(int argc, char* argv[])
 	sprintf(OutFile, "%s.avE", OutFileBase);
 	//SaveSummaryResults();
 
+	Bitmap_Finalise();
 
-#ifdef WIN32_BM
-	Gdiplus::GdiplusShutdown(m_gdiplusToken);
-#endif
 	fprintf(stderr, "Extinction in %i out of %i runs\n", P.NRactE, P.NRactNE + P.NRactE);
 	fprintf(stderr, "Model ran in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
 	fprintf(stderr, "Model finished\n");
@@ -2429,7 +2427,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 
 	if (P.OutputBitmap)
 	{
-#ifdef WIN32_BM
+#ifdef _WIN32
 		//if (P.OutputBitmap == 1)
 		//{
 		//	char buf[200];

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -31,6 +31,15 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
+// Use the POSIX name for case-insensitive string comparison: strcasecmp.
+#ifdef _WIN32
+// Windows calls it _stricmp so make strcasecmp an alias.
+#include <string.h>
+#define strcasecmp _stricmp
+#else
+#include <strings.h>
+#endif
+
 void ReadParams(char*, char*);
 void ReadInterventions(char*);
 int GetXMLNode(FILE*, const char*, const char*, char*, int);
@@ -284,7 +293,7 @@ int main(int argc, char* argv[])
 			else if (argv[i][1] == 'B' && argv[i][2] == 'M' && argv[i][3] == ':')
 			{
 				sscanf(&argv[i][4], "%s", buf);
-				if (stricmp(buf, "png") == 0)
+				if (strcasecmp(buf, "png") == 0)
 				{
 #if defined(IMAGE_MAGICK) || defined(_WIN32)
 				  P.BitmapFormat = BF_PNG;
@@ -293,7 +302,7 @@ int main(int argc, char* argv[])
 				  Perr = 1;
 #endif
 				}
-				else if (stricmp(buf, "bmp") == 0)
+				else if (strcasecmp(buf, "bmp") == 0)
 				{
 				  P.BitmapFormat = BF_BMP;
 				}

--- a/src/Param.h
+++ b/src/Param.h
@@ -6,6 +6,13 @@
 #include "Country.h"
 #include "Constants.h"
 
+/** @brief Enumeration of bitmap formats. */
+enum BitmapFormats
+{
+  BF_PNG = 0,  // PNG - default if IMAGE_MAGICK or _WIN32 defined
+  BF_BMP = 1   // BMP - fall-back
+};
+
 /**
  * @brief Stores the parameters for the simulation.
  *
@@ -43,6 +50,7 @@ typedef struct PARAM {
 	int bheight2; // Height in pixels of the entire bitmap output, including both the spectrum at the top and the map area
 	int bminx, bminy;
 	int OutputBitmap; // Whether to output a bitmap
+	BitmapFormats BitmapFormat; // Format of bitmap (platform dependent and command-line /BM: specified).
 	int DoSI, DoHeteroDensity, DoPeriodicBoundaries, DoImmuneBitmap, OutputBitmapDetected; //added OutputBitmapDetected - ggilani 04/08/15
 	int DoHouseholds, DoPlaces, PlaceTypeNum, Nplace[NUM_PLACE_TYPES], SmallEpidemicCases, DoPlaceGroupTreat;
 	int NumInitialInfections[MAX_NUM_SEED_LOCATIONS], DoRandomInitialInfectionLoc, DoAllInitialInfectioninSameLoc;

--- a/tests/regressiontest_UK_100th.py
+++ b/tests/regressiontest_UK_100th.py
@@ -90,7 +90,7 @@ updir1 = os.pardir + os.sep
 shutil.rmtree(testdir, True)
 os.mkdir(testdir)
 os.chdir(testdir)
-subprocess.check_call(['cmake', '-DCMAKE_CXX_FLAGS=-DNO_WIN32_BM', updir2 + 'src'])
+subprocess.check_call(['cmake', updir2 + 'src'])
 subprocess.check_call(['cmake', '--build', '.'])
 
 if os.name == 'nt':
@@ -114,7 +114,7 @@ if not os.path.exists(wpop_file):
 # Run the simulation.
 print('=== Starting building network:')
 subprocess.check_call(
-    [covidsim_exe, '/c:1',
+    [covidsim_exe, '/c:1', '/BM:BMP',
      '/PP:' +  updir1 + 'preUK_R0=2.0.txt',
      '/P:' + updir1  + 'p_NoInt.txt', '/CLP1:100000',
      '/CLP2:0', '/O:NoInt_R0=2.2', '/D:' + wpop_file, '/M:' + wpop_bin,
@@ -124,7 +124,7 @@ subprocess.check_call(
     ])
 print('=== Starting running repeat:')
 subprocess.check_call(
-    [covidsim_exe, '/c:1',
+    [covidsim_exe, '/c:1', '/BM:BMP',
      '/PP:' +  updir1 + 'preUK_R0=2.0.txt',
      '/P:' + updir1  + 'p_NoInt.txt', '/CLP1:100000',
      '/CLP2:0', '/O:NoInt_R0=2.2-repeat', '/D:' + wpop_bin,
@@ -134,7 +134,7 @@ subprocess.check_call(
     ])
 print('=== Starting running:')
 subprocess.check_call(
-    [covidsim_exe, '/c:1',
+    [covidsim_exe, '/c:1', '/BM:BMP',
      '/PP:' + updir1 + 'preUK_R0=2.0.txt',
      '/P:' + updir1 + 'p_PC7_CI_HQ_SD.txt', '/CLP1:100',
      '/CLP2:91', '/CLP3:121', '/CLP4:121', '/O:CI_100_91_R0=2.2',


### PR DESCRIPTION
This removes `WIN32_BM` and makes it a command line option instead.  Enabling us to choose BMP or PNG format output at runtime.