### PR TITLE
InitKernel-related tidyups

### DIFF
--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -42,6 +42,8 @@ void InitKernel(int DoPlaces, double norm)
 		Kernel = PowerKernelUS;
 	else if (P.KernelType == 7)
 		Kernel = PowerExpKernel;
+	else
+		ERR_CRITICAL_FMT("Unknown kernel type %d.\n", P.KernelType);
 #pragma omp parallel for private(i) schedule(static,500) //added private i
 	for (i = 0; i <= P.NKR; i++)
 	{

--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -6,8 +6,6 @@
 #include "Dist.h"
 #include "Param.h"
 
-double(*Kernel)(double);
-
 // To speed up calculation of kernel values we provide a couple of lookup
 // tables.
 //
@@ -28,6 +26,7 @@ double *nKernel, *nKernelHR;
 void InitKernel(int DoPlaces, double norm)
 {
 	int i, j;
+	double(*Kernel)(double);
 
 	if (P.KernelType == 1)
 		Kernel = ExpKernel;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -191,11 +191,6 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	P.KernelDelta = t / P.NKR;
 	//	fprintf(stderr,"** %i %lg %lg %lg %lg | %lg %lg %lg %lg \n",P.DoUTM_coords,P.SpatialBoundingBox[0],P.SpatialBoundingBox[1],P.SpatialBoundingBox[2],P.SpatialBoundingBox[3],P.width,P.height,t,P.KernelDelta);
 	fprintf(stderr, "Coords xmcell=%lg m   ymcell = %lg m\n", sqrt(dist2_raw(P.width / 2, P.height / 2, P.width / 2 + P.mcwidth, P.height / 2)), sqrt(dist2_raw(P.width / 2, P.height / 2, P.width / 2, P.height / 2 + P.mcheight)));
-	P.KernelShape = P.MoveKernelShape;
-	P.KernelScale = P.MoveKernelScale;
-	P.KernelP3 = P.MoveKernelP3;
-	P.KernelP4 = P.MoveKernelP4;
-	P.KernelType = P.MoveKernelType;
 	t2 = 0.0;
 
 	SetupPopulation(DensityFile, SchoolFile, RegDemogFile);
@@ -304,6 +299,11 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	P.KeyWorkerNum = P.KeyWorkerIncHouseNum = m = l = 0;
 
 	fprintf(stderr, "Initialising kernel...\n");
+	P.KernelShape = P.MoveKernelShape;
+	P.KernelScale = P.MoveKernelScale;
+	P.KernelP3 = P.MoveKernelP3;
+	P.KernelP4 = P.MoveKernelP4;
+	P.KernelType = P.MoveKernelType;
 	InitKernel(0, 1.0);
 
 	if (P.DoPlaces)
@@ -1613,12 +1613,12 @@ void SetupAirports(void)
 				Airports[i].Inv_DestPlaces[l] = j;
 			}
 		}
+	for (i = 0; i < P.Nplace[P.HotelPlaceType]; i++) Places[P.HotelPlaceType][i].n = 0;
 	P.KernelType = P.MoveKernelType;
 	P.KernelScale = P.MoveKernelScale;
 	P.KernelShape = P.MoveKernelShape;
 	P.KernelP3 = P.MoveKernelP3;
 	P.KernelP4 = P.MoveKernelP4;
-	for (i = 0; i < P.Nplace[P.HotelPlaceType]; i++) Places[P.HotelPlaceType][i].n = 0;
 	InitKernel(0, 1.0);
 	fprintf(stderr, "\nAirport initialisation completed successfully\n");
 }
@@ -2282,11 +2282,6 @@ void AssignPeopleToPlaces(void)
 			free(Cells[i].susceptible);
 			Cells[i].susceptible = Cells[i].infected;
 		}
-		P.KernelScale = P.MoveKernelScale;
-		P.KernelShape = P.MoveKernelShape;
-		P.KernelType = P.MoveKernelType;
-		P.KernelP3 = P.MoveKernelP3;
-		P.KernelP4 = P.MoveKernelP4;
 	}
 
 }
@@ -2477,10 +2472,6 @@ void LoadPeopleToPlaces(char* NetworkFile)
 			}
 	*/	fprintf(stderr, "\n");
 	fclose(dat);
-	P.KernelScale = P.MoveKernelScale;
-	P.KernelShape = P.MoveKernelShape;
-	P.KernelP3 = P.MoveKernelP3;
-	P.KernelP4 = P.MoveKernelP4;
 }
 void SavePeopleToPlaces(char* NetworkFile)
 {


### PR DESCRIPTION
* Give an error if we are asked to use a non-existent kernel type
* Always (and only) set the kernel parameters immediately before calling InitKernel. Makes it easier to see how it's being initialised, and also means the parameters always match the kernel.
* Make a variable local, rather than global
