### PR TITLE
Remove redundant double to int conversions

### DIFF
--- a/src/Dist.cpp
+++ b/src/Dist.cpp
@@ -7,13 +7,14 @@
 
 double sinx[361], cosx[361], asin2sqx[1001];
 
-//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** 
+//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 //// **** DISTANCE FUNCTIONS (return distance-squared, which is input for every Kernel function)
-//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** 
+//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 
 double dist2UTM(double x1, double y1, double x2, double y2)
 {
-	double x, y, cy1, cy2, yt, xi, yi;
+	double x, y, cy1, cy2, yt;
+	int xi, yi;
 
 	x = fabs(x1 - x2) / 2;
 	y = fabs(y1 - y2) / 2;
@@ -21,22 +22,22 @@ double dist2UTM(double x1, double y1, double x2, double y2)
 	yi = floor(y);
 	x -= xi;
 	y -= yi;
-	x = (1 - x) * sinx[(int)xi] + x * sinx[((int)xi) + 1];
+	x = (1 - x) * sinx[xi] + x * sinx[xi + 1];
 	x = x * x;
-	y = (1 - y) * sinx[(int)yi] + y * sinx[((int)yi) + 1];
+	y = (1 - y) * sinx[yi] + y * sinx[yi + 1];
 	y = y * y;
 	yt = fabs(y1 + P.SpatialBoundingBox[1]);
 	yi = floor(yt);
 	cy1 = yt - yi;
-	cy1 = (1 - cy1) * cosx[((int)yi)] + cy1 * cosx[((int)yi) + 1];
+	cy1 = (1 - cy1) * cosx[yi] + cy1 * cosx[yi + 1];
 	yt = fabs(y2 + P.SpatialBoundingBox[1]);
 	yi = floor(yt);
 	cy2 = yt - yi;
-	cy2 = (1 - cy2) * cosx[((int)yi)] + cy2 * cosx[((int)yi) + 1];
+	cy2 = (1 - cy2) * cosx[yi] + cy2 * cosx[yi + 1];
 	x = fabs(1000 * (y + x * cy1 * cy2));
 	xi = floor(x);
 	x -= xi;
-	y = (1 - x) * asin2sqx[((int)xi)] + x * asin2sqx[((int)xi) + 1];
+	y = (1 - x) * asin2sqx[xi] + x * asin2sqx[xi + 1];
 	return 4 * EARTHRADIUS * EARTHRADIUS * y;
 }
 double dist2(person* a, person* b)


### PR DESCRIPTION
In `Dist.cpp` `xi` and `yi` are declared as double and converted to int 10 times, while being subtracted only 4 times from doubles. Instead of that, `xi` and `yi` can be outright declared as `int`. Based on my understanding, this should be more efficient.