### PR TITLE
Avoid ternary operator in StepKernel

### DIFF
--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -100,7 +100,7 @@ double GaussianKernel(double r2)
 }
 double StepKernel(double r2)
 {
-	return (r2 > P.KernelScale * P.KernelScale) ? 0 : 1;
+	return r2 <= P.KernelScale * P.KernelScale;
 }
 double PowerExpKernel(double r2)
 {


### PR DESCRIPTION
The statement is logically equivalent to the one I proposed. `<=` probably can be replaced with `<`, since it's the comparision of two doubles.