### PR TITLE
Fix kernel index issues with large geographies (Russia in particular)

### DIFF
--- a/data/admin_units/Russia_admin.txt
+++ b/data/admin_units/Russia_admin.txt
@@ -16,6 +16,11 @@
 [Fix population size at specified value]
 1
 
+[Longitude cut line]
+0.0
+# Russia goes from around 19 degrees to -170 dgrees longitude, so need
+# different cut line to default of -180.0
+
 [Number of countries to include]
 1
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -473,6 +473,9 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (!(ParamFile_dat = fopen(ParamFile, "rb"))) ERR_CRITICAL("Unable to open parameter file\n");
 	PreParamFile_dat = fopen(PreParamFile, "rb");
 	if (!(AdminFile_dat = fopen(AdunitFile, "rb"))) AdminFile_dat = ParamFile_dat;
+	if (!GetInputParameter2(ParamFile_dat, AdminFile_dat, "Longitude cut line", "%lf", (void*) & (P.LongitudeCutLine), 1, 1, 0)) {
+		P.LongitudeCutLine = -360.0;
+	}
 	AgeSuscScale = 1.0;
 		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Update timestep", "%lf", (void*) & (P.TimeStep), 1, 1, 0);
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Sampling timestep", "%lf", (void*) & (P.SampleStep), 1, 1, 0);

--- a/src/Param.h
+++ b/src/Param.h
@@ -63,6 +63,7 @@ typedef struct PARAM {
 	long nextSetupSeed1, nextSetupSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for setup
 	long nextRunSeed1, nextRunSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for the model
 	int ResetSeeds,KeepSameSeeds, ResetSeedsPostIntervention, ResetSeedsFlag, TimeToResetSeeds;
+	double LongitudeCutLine; // Longitude to image earth is cut at to produce a flat map.  Default -360 degrees (effectively -180).  Use to ensure countries have a contiguous boundary
 	double SpatialBoundingBox[4], LocationInitialInfection[MAX_NUM_SEED_LOCATIONS][2], InitialInfectionsAdminUnitWeight[MAX_NUM_SEED_LOCATIONS], TimeStepsPerDay;
 	double FalsePositiveRate, FalsePositivePerCapitaIncidence, FalsePositiveAgeRate[NUM_AGE_GROUPS];
 	double latent_icdf[CDF_RES + 1], infectious_icdf[CDF_RES + 1], infectious_prof[INFPROF_RES + 1], infectiousness[MAX_INFECTIOUS_STEPS];

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -152,6 +152,12 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		fprintf(stderr, "Adjusted bounding box = (%lg, %lg)- (%lg, %lg)\n", P.SpatialBoundingBox[0], P.SpatialBoundingBox[1], P.SpatialBoundingBox[2], P.SpatialBoundingBox[3]);
 		fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.NC, P.ncw, P.nch);
 		fprintf(stderr, "Population size = %i \n", P.PopSize);
+		if (P.width > 180) {
+			fprintf(stderr, "WARNING: Width of bounding box > 180 degrees.  Results may be inaccurate.\n");
+		}
+		if (P.height > 90) {
+			fprintf(stderr, "WARNING: Height of bounding box > 90 degrees.  Results may be inaccurate.\n");
+		}
 		s = 1;
 		P.DoPeriodicBoundaries = 0;
 	}

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -81,7 +81,14 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 					sscanf(buf, "%lg %lg %lg %i", &x, &y, &t, &i2);
 					l = 0;
 				}
-				BF[index].x = x;
+				// Ensure we use an x which gives us a contiguous whole for the
+				// geography.
+				if (x >= P.LongitudeCutLine) {
+					BF[index].x = x;
+				}
+				else {
+					BF[index].x = x + 360;
+				}
 				BF[index].y = y;
 				BF[index].pop = t;
 				BF[index].cnt = i2;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -191,7 +191,12 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.LocationInitialInfection[i][0] -= P.SpatialBoundingBox[0];
 		P.LocationInitialInfection[i][1] -= P.SpatialBoundingBox[1];
 	}
+	// Find longest distance - may not be diagonally across the bounding box.
 	t = dist2_raw(0, 0, P.width, P.height);
+	double tw = dist2_raw(0, 0, P.width, 0);
+	double th = dist2_raw(0, 0, 0, P.height);
+	if (tw > t) t = tw;
+	if (th > t) t = th;
 	if (P.DoPeriodicBoundaries) t *= 0.25;
 	if (!(nKernel = (double*)calloc(P.NKR + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");
 	if (!(nKernelHR = (double*)calloc(P.NKR + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");


### PR DESCRIPTION
We are getting `r too large in NumKernel` errors when processing the Russia geography.  This PR fixes the issue.

There are two issues:

 1. Russia spans -180/180 degrees longitude and so the cut we do to flatten the earth causes it to have the wrong geometry in the model.  Add `[Longitude cut line]` parameter to enable us to move where we cut the earth to give Russia a contiguous geometry.

 2. We were calculating the longest distance possible in the bounding box of the geographies as the distance bottom-left to top-right.  This may not hold on a sphere.  Check whether Going along or up the sides of the bounding box will give us a longer distance, and use that.

@weshinsley : I have only updated Russia's admin file to handle the -180/180 cut - you may want to review the population density files to see if there are any other countries whose admin files need a `[Longitude cut line]` parameter.
