### PR TITLE
Install Python3 on CentOS 7

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -30,7 +30,7 @@ case "$distro_id" in
 
     'centos'|'rhel')
         yum -y install epel-release
-        yum -y install cmake3 make gcc-c++
+        yum -y install cmake3 make gcc-c++ python3
         ln -s /bin/cmake3 /bin/cmake
         ;;
 


### PR DESCRIPTION
Fixes the latest build failures due to an upstream config change.