### PR TITLE
Allow passing of any extra flags to integration-test.py.

### DIFF
--- a/tests/regressiontest_UK_100th.py
+++ b/tests/regressiontest_UK_100th.py
@@ -94,7 +94,6 @@ cmd = [
         "--r", "1.1"
 ]
 
-if len(sys.argv) > 1 and sys.argv[1] == '--accept':
-    cmd.append("--accept")
+cmd.extend(sys.argv[1:])
 print("Command line: " + " ".join(cmd))
 process = subprocess.run(cmd, check=True)

--- a/tests/regressiontest_US_based.py
+++ b/tests/regressiontest_US_based.py
@@ -93,7 +93,6 @@ cmd = [
         "--popfile", os.path.join(wpop_file_gz)
 ]
 
-if len(sys.argv) > 1 and sys.argv[1] == '--accept':
-    cmd.append("--accept")
+cmd.extend(sys.argv[1:])
 print("Command line: " + " ".join(cmd))
 process = subprocess.run(cmd, check=True)


### PR DESCRIPTION
e.g. --covidsim ..\out\build\x64-Release\src\CovidSim.exe
allows me to run the regression tests on Windows