### PR TITLE
Replaced header guards with #pragma once.

### DIFF
--- a/src/BinIO.h
+++ b/src/BinIO.h
@@ -1,2 +1,4 @@
+#pragma once
+
 size_t fwrite_big(void *,size_t ,size_t , FILE *);
 size_t fread_big(void *,size_t ,size_t , FILE *);

--- a/src/Bitmap.h
+++ b/src/Bitmap.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_BITMAP_H_INCLUDED_
-#define COVIDSIM_BITMAP_H_INCLUDED_
+#pragma once
 
 #include <cstdint>
 
@@ -46,5 +45,3 @@ void OutputBitmap(int);
 void InitBMHead();
 
 void Bitmap_Finalise();
-
-#endif // COVIDSIM_BITMAP_H_INCLUDED_

--- a/src/CalcInfSusc.h
+++ b/src/CalcInfSusc.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_CALCINFSUSC_H_
-#define COVIDSIM_CALCINFSUSC_H_
+#pragma once
 
 double CalcHouseInf(int, unsigned short int);
 double CalcPlaceInf(int, int, unsigned short int);
@@ -9,5 +8,3 @@ double CalcHouseSusc(int, unsigned short int, int, int);
 double CalcPlaceSusc(int, int, unsigned short int, int, int);
 double CalcSpatialSusc(int, unsigned short int, int, int);
 double CalcPersonSusc(int, unsigned short int, int, int);
-
-#endif // COVIDSIM_CALCINFSUSC_

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_CONSTANTS_H_INCLUDED_
-#define COVIDSIM_CONSTANTS_H_INCLUDED_
+#pragma once
 
 /**
  * Math constant defined as the ratio of a circle's circumference to its diameter.
@@ -97,5 +96,3 @@ const int MIN_HOTELS_PER_AIRPORT = 20;
 const int HOTELS_PER_1000PASSENGER = 10;
 
 const int MAX_NUM_INTERVENTION_CHANGE_TIMES = 100; // may want to make this intervention-specifc, but keep simple for now.
-
-#endif // COVIDSIM_CONSTANTS_H_INCLUDED_

--- a/src/Country.h
+++ b/src/Country.h
@@ -1,6 +1,4 @@
-#ifndef COVIDSIM_COUNTRY_H_INCLUDED_
-#define COVIDSIM_COUNTRY_H_INCLUDED_
-
+#pragma once
 
 const int MAX_HOUSEHOLD_SIZE = 10;
 const int MAX_INTERVENTION_TYPES = 1;
@@ -15,5 +13,3 @@ const int MAX_ADUNITS = 3200;
 const int MAX_ABSENT_TIME = 8;
 
 const int MAX_DIST = 2000;
-
-#endif // COVIDSIM_COUNTRY_H_INCLUDED_

--- a/src/CovidSim.h
+++ b/src/CovidSim.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_COVIDSIM_H_INCLUDED_
-#define COVIDSIM_COVIDSIM_H_INCLUDED_
+#pragma once
 
 // Compiling with Clang from VS requires libomp.lib to be included in
 // Project, Properties, Input, Additional Dependencies, however
@@ -24,5 +23,3 @@
 
 #include "Country.h"
 #include "Constants.h"
-
-#endif // COVIDSIM_COVIDSIM_H_INCLUDED_

--- a/src/Dist.h
+++ b/src/Dist.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_DIST_H_INCLUDED_
-#define COVIDSIM_DIST_H_INCLUDED_
+#pragma once
 
 #include "Model.h"
 extern double sinx[361], cosx[361], asin2sqx[1001];
@@ -9,5 +8,3 @@ double dist2_cc(Cell*, Cell*);
 double dist2_cc_min(Cell*, Cell*);
 double dist2_mm(Microcell*, Microcell*);
 double dist2_raw(double, double, double, double);
-
-#endif // COVIDSIM_DIST_H_INCLUDED_

--- a/src/Error.h
+++ b/src/Error.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_ERROR_H_INCLUDED_
-#define COVIDSIM_ERROR_H_INCLUDED_
+#pragma once
 
 #define ERR_CRITICAL(msg) ErrorCritical(msg, __FILE__, __LINE__)
 #define ERR_CRITICAL_FMT(fmt, ...) ErrorCritical(fmt, __FILE__, __LINE__, __VA_ARGS__)
@@ -12,5 +11,3 @@ void ErrorCritical(const char* msg, const char* file, int line, ...)
   __attribute__ ((noreturn)) __attribute__ ((format (printf, 1, 4)))
 #endif
 ;
-
-#endif // COVIDSIM_ERROR_H_INCLUDED_

--- a/src/InfStat.h
+++ b/src/InfStat.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_INFSTAT_H_INCLUDED_
-#define COVIDSIM_INFSTAT_H_INCLUDED_
+#pragma once
 
 //// Infection Status definitons / labels (generally positive value indicates asymptomatic infection, negative value indicates symptomatic infection).
 enum InfStat {
@@ -28,5 +27,3 @@ enum Severity {
 	Severity_Dead = 5,													//// label to avoid double counting. Not sure you need.
 	Severity_Recovered = 6											//// label to avoid double counting. Not sure you need.
 };
-
-#endif // COVIDSIM_INFSTAT_H_INCLUDED_

--- a/src/Kernels.h
+++ b/src/Kernels.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_KERNELS_H_INCLUDED_
-#define COVIDSIM_KERNELS_H_INCLUDED_
+#pragma once
 
 extern double *nKernel, *nKernelHR;
 
@@ -12,5 +11,3 @@ double PowerExpKernel(double);
 double GaussianKernel(double);
 double StepKernel(double);
 double numKernel(double);
-
-#endif // COVIDSIM_KERNELS_H_INCLUDED_

--- a/src/Model.h
+++ b/src/Model.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_MODEL_H_INCLUDED_
-#define COVIDSIM_MODEL_H_INCLUDED_
+#pragma once
 
 #include <cstddef>
 
@@ -395,5 +394,3 @@ extern double PropPlacesC[NUM_AGE_GROUPS * AGE_GROUP_WIDTH][NUM_PLACE_TYPES], Ai
 extern double PeakHeightSum, PeakHeightSS, PeakTimeSum, PeakTimeSS;
 
 extern int DoInitUpdateProbs;
-
-#endif // COVIDSIM_MODEL_H_INCLUDED_

--- a/src/ModelMacros.h
+++ b/src/ModelMacros.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_MODELMACROS_H_INCLUDED_
-#define COVIDSIM_MODELMACROS_H_INCLUDED_
+#pragma once
 
 #include <climits>
 
@@ -21,5 +20,3 @@
 
 #define HOST_AGE_YEAR(x) (Hosts[x].age)
 #define HOST_AGE_GROUP(x) (Hosts[x].age / AGE_GROUP_WIDTH)
-
-#endif // COVIDSIM_MODELMACROS_H_INCLUDED_

--- a/src/Param.h
+++ b/src/Param.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_PARAM_H_INCLUDED_
-#define COVIDSIM_PARAM_H_INCLUDED_
+#pragma once
 
 #include <inttypes.h>
 
@@ -337,5 +336,3 @@ struct Param
 };
 
 extern Param P;
-
-#endif // COVIDSIM_PARAM_H_INCLUDED_

--- a/src/Rand.h
+++ b/src/Rand.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_RAND_H_INCLUDED_
-#define COVIDSIM_RAND_H_INCLUDED_
+#pragma once
 
 #include <inttypes.h>
 
@@ -34,5 +33,3 @@ double gen_gamma_mt(double, double, int);
 //added some new lognormal sampling functions: ggilani 09/02/17
 double gen_lognormal(double, double);
 void SampleWithoutReplacement(int, int, int);
-
-#endif // COVIDSIM_RAND_H_INCLUDED_

--- a/src/SetupModel.h
+++ b/src/SetupModel.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_SETUPMODEL_H_INCLUDED_
-#define COVIDSIM_SETUPMODEL_H_INCLUDED_
+#pragma once
 
 void SetupModel(char*, char*, char*, char*);
 void SetupPopulation(char*, char*);
@@ -23,5 +22,3 @@ struct BinFile
 };
 
 extern char OutFile[1024],OutDensFile[1024];
-
-#endif // COVIDSIM_SETUPMODEL_H_INCLUDED_

--- a/src/Sweep.h
+++ b/src/Sweep.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_SWEEP_H_INCLUDED_
-#define COVIDSIM_SWEEP_H_INCLUDED_
+#pragma once
 
 void TravelReturnSweep(double);
 void TravelDepartSweep(double);
@@ -8,5 +7,3 @@ void IncubRecoverySweep(double, int); //added int as argument to record run numb
 int TreatSweep(double);
 //void HospitalSweep(double); //added hospital sweep function: ggilani - 10/11/14
 void DigitalContactTracingSweep(double); // added function to update contact tracing number
-
-#endif // COVIDSIM_SWEEP_H_INCLUDED_

--- a/src/Update.h
+++ b/src/Update.h
@@ -1,5 +1,4 @@
-#ifndef COVIDSIM_UPDATE_H_INCLUDED_
-#define COVIDSIM_UPDATE_H_INCLUDED_
+#pragma once
 
 void DoImmune(int);
 void DoInfect(int, double, int, int); //added int as argument to InfectSweep to record run number: ggilani - 15/10/14
@@ -23,5 +22,3 @@ void DoCritical(int, int);
 void DoRecoveringFromCritical(int, int);
 void DoRecover_FromSeverity(int, int);
 void DoDeath_FromCriticalorSARIorILI(int, int);
-
-#endif // COVIDSIM_UPDATE_H_INCLUDED_


### PR DESCRIPTION
In response to #204 :

@zdroid picked the easier solution of using the header guards, since those were used more consistently, and he wasn't sure how others felt about pragma once.

However, zdroid and another developer expressed that they'd prefer pragma once, and I agree, so I went through all of the headers, and replaced the header guards.