### PR TITLE
Use a back port of std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt
 
 # CMake setup
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.11)
 
 # Project initialisation
 project("CovidSim")
@@ -47,6 +47,7 @@ endif()
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 14)
 
+add_subdirectory(third_party)
 add_subdirectory(src)
 
 if(WIN32 AND USE_WIN32_BMP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # CMakeLists.txt for src directory
+include_directories("${filesystem_SOURCE_DIR}/include")
 
 # Set up the IDE
 set(MAIN_SRC_FILES CovidSim.cpp BinIO.cpp Rand.cpp Error.cpp Dist.cpp Kernels.cpp Bitmap.cpp SetupModel.cpp CalcInfSusc.cpp Sweep.cpp Update.cpp)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -5,6 +5,9 @@
 #include <errno.h>
 #include <stddef.h>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #include "CovidSim.h"
 #include "BinIO.h"
 #include "Rand.h"


### PR DESCRIPTION
Not actually sure that this needed anymore. Admittedly error statuses are checked on fopen which may fail because a file either does or doesn't exist. Would be better to use filesystem::exists in that case.