### PR TITLE
Fix doxygen build on master

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: install dependencies
+      run: sudo ./ci/install_dependencies.sh
+
     - name: Doxygen Build
       run: |
         mkdir build && cd build

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,8 +1,5 @@
 name: Doxygen Action
-on:
-  push:
-    branches:
-      - master
+on: [push]
 
 jobs:
   doxygen:
@@ -26,6 +23,7 @@ jobs:
 
     - name: Doxygen Deploy
       uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'master' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/docs/html

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -25,7 +25,7 @@ case "$distro_id" in
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake make g++ python3
+        apt-get install -y cmake make g++ python3 doxygen
         ;;
 
     'centos'|'rhel')


### PR DESCRIPTION
This PR fixes the doxygen build failures on master.  Also makes the flow run on all pushes (but only deploy on a push to master) to make checking for issues easier down the line)

(Caused by #238 and doxygen CI flow historically only being run on pushes to master - CC @zebmason).