### PR TITLE
Move the `nEvents < P.MaxInfEvents` test inside the critical section

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -83,7 +83,7 @@ Airport* Airports;
 BitmapHeader* bmh;
 //added declaration of pointer to events log: ggilani - 10/10/2014
 Events* InfEventLog;
-int* nEvents;
+int nEvents;
 
 double inftype[INFECT_TYPE_MASK], inftype_av[INFECT_TYPE_MASK], infcountry[MAX_COUNTRIES], infcountry_av[MAX_COUNTRIES], infcountry_num[MAX_COUNTRIES];
 double indivR0[MAX_SEC_REC][MAX_GEN_REC], indivR0_av[MAX_SEC_REC][MAX_GEN_REC];
@@ -2783,7 +2783,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 	//initialise event log to zero at the beginning of every run: ggilani - 10/10/2014. UPDATE: 15/10/14 - we are now going to store all events from all realisations in one file
 	if ((P.DoRecordInfEvents) && (P.RecordInfEventsPerRun))
 	{
-		*nEvents = 0;
+		nEvents = 0;
 		for (int i = 0; i < P.MaxInfEvents; i++)
 		{
 			InfEventLog[i].t = InfEventLog[i].infectee_x = InfEventLog[i].infectee_y = InfEventLog[i].t_infector = 0.0;
@@ -4193,7 +4193,7 @@ void SaveEvents(void)
 	sprintf(outname, "%s.infevents.xls", OutFile);
 	if (!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open output file\n");
 	fprintf(dat, "type,t,thread,ind_infectee,cell_infectee,listpos_infectee,adunit_infectee,x_infectee,y_infectee,t_infector,ind_infector,cell_infector\n");
-	for (i = 0; i < *nEvents; i++)
+	for (i = 0; i < nEvents; i++)
 	{
 		fprintf(dat, "%i\t%.10f\t%i\t%i\t%i\t%i\t%i\t%.10f\t%.10f\t%.10f\t%i\t%i\n",
 			InfEventLog[i].type, InfEventLog[i].t, InfEventLog[i].thread, InfEventLog[i].infectee_ind, InfEventLog[i].infectee_cell, InfEventLog[i].listpos, InfEventLog[i].infectee_adunit, InfEventLog[i].infectee_x, InfEventLog[i].infectee_y, InfEventLog[i].t_infector, InfEventLog[i].infector_ind, InfEventLog[i].infector_cell);

--- a/src/Model.h
+++ b/src/Model.h
@@ -368,7 +368,7 @@ extern Results* TimeSeries, *TSMean, *TSVar, *TSMeanNE, *TSVarNE, *TSMeanE, *TSV
 
 extern Airport* Airports;
 extern Events* InfEventLog;
-extern int* nEvents;
+extern int nEvents;
 
 
 extern double inftype[INFECT_TYPE_MASK], inftype_av[INFECT_TYPE_MASK], infcountry[MAX_COUNTRIES], infcountry_av[MAX_COUNTRIES], infcountry_num[MAX_COUNTRIES];

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -287,7 +287,6 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	if (P.DoRecordInfEvents)
 	{
 		if (!(InfEventLog = (Events*)calloc(P.MaxInfEvents, sizeof(Events)))) ERR_CRITICAL("Unable to allocate events storage\n");
-		if (!(nEvents = (int*)calloc(1, sizeof(int)))) ERR_CRITICAL("Unable to allocate events storage\n");
 	}
 
 	if(P.OutputNonSeverity) SaveAgeDistrib();

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -142,7 +142,7 @@ void DoInfect(int ai, double t, int tn, int run) // Change person from susceptib
 		//added this to record event if flag is set to 1 : ggilani - 10/10/2014
 		if (P.DoRecordInfEvents)
 		{
-			if (*nEvents < P.MaxInfEvents)
+			if (nEvents < P.MaxInfEvents)
 			{
 				RecordEvent(t, ai, run, 0, tn); //added int as argument to RecordEvent to record run number: ggilani - 15/10/14
 			}
@@ -164,7 +164,6 @@ void RecordEvent(double t, int ai, int run, int type, int tn) //added int as arg
 	 * Parameters:
 	 *	t: time of infection event
 	 *	ai: index of infectee
-	 *	nEventsPoint: pointer to number of events
 	 *
 	 * Returns: void
 	 *
@@ -178,41 +177,41 @@ void RecordEvent(double t, int ai, int run, int type, int tn) //added int as arg
 	//Save information to event
 #pragma omp critical (inf_event)
 	{
-		InfEventLog[*nEvents].run = run;
-		InfEventLog[*nEvents].type = type;
-		InfEventLog[*nEvents].t = t;
-		InfEventLog[*nEvents].infectee_ind = ai;
-		InfEventLog[*nEvents].infectee_adunit = Mcells[Hosts[ai].mcell].adunit;
-		InfEventLog[*nEvents].infectee_x = Households[Hosts[ai].hh].loc_x + P.SpatialBoundingBox[0];
-		InfEventLog[*nEvents].infectee_y = Households[Hosts[ai].hh].loc_y + P.SpatialBoundingBox[1];
-		InfEventLog[*nEvents].listpos = Hosts[ai].listpos;
-		InfEventLog[*nEvents].infectee_cell = Hosts[ai].pcell;
-		InfEventLog[*nEvents].thread = tn;
+		InfEventLog[nEvents].run = run;
+		InfEventLog[nEvents].type = type;
+		InfEventLog[nEvents].t = t;
+		InfEventLog[nEvents].infectee_ind = ai;
+		InfEventLog[nEvents].infectee_adunit = Mcells[Hosts[ai].mcell].adunit;
+		InfEventLog[nEvents].infectee_x = Households[Hosts[ai].hh].loc_x + P.SpatialBoundingBox[0];
+		InfEventLog[nEvents].infectee_y = Households[Hosts[ai].hh].loc_y + P.SpatialBoundingBox[1];
+		InfEventLog[nEvents].listpos = Hosts[ai].listpos;
+		InfEventLog[nEvents].infectee_cell = Hosts[ai].pcell;
+		InfEventLog[nEvents].thread = tn;
 		if (type == 0) //infection event - record time of onset of infector and infector
 		{
-			InfEventLog[*nEvents].infector_ind = bi;
+			InfEventLog[nEvents].infector_ind = bi;
 			if (bi < 0)
 			{
-				InfEventLog[*nEvents].t_infector = -1;
-				InfEventLog[*nEvents].infector_cell = -1;
+				InfEventLog[nEvents].t_infector = -1;
+				InfEventLog[nEvents].infector_cell = -1;
 			}
 			else
 			{
-				InfEventLog[*nEvents].t_infector = (int)(Hosts[bi].infection_time / P.TimeStepsPerDay);
-				InfEventLog[*nEvents].infector_cell = Hosts[bi].pcell;
+				InfEventLog[nEvents].t_infector = (int)(Hosts[bi].infection_time / P.TimeStepsPerDay);
+				InfEventLog[nEvents].infector_cell = Hosts[bi].pcell;
 			}
 		}
 		else if (type == 1) //onset event - record infectee's onset time
 		{
-			InfEventLog[*nEvents].t_infector = (int)(Hosts[ai].infection_time / P.TimeStepsPerDay);
+			InfEventLog[nEvents].t_infector = (int)(Hosts[ai].infection_time / P.TimeStepsPerDay);
 		}
 		else if ((type == 2) || (type == 3)) //recovery or death event - record infectee's onset time
 		{
-			InfEventLog[*nEvents].t_infector = (int)(Hosts[ai].latent_time / P.TimeStepsPerDay);
+			InfEventLog[nEvents].t_infector = (int)(Hosts[ai].latent_time / P.TimeStepsPerDay);
 		}
 
 		//increment the index of the infection event
-		(*nEvents)++;
+		nEvents++;
 	}
 
 }

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -142,10 +142,7 @@ void DoInfect(int ai, double t, int tn, int run) // Change person from susceptib
 		//added this to record event if flag is set to 1 : ggilani - 10/10/2014
 		if (P.DoRecordInfEvents)
 		{
-			if (nEvents < P.MaxInfEvents)
-			{
-				RecordEvent(t, ai, run, 0, tn); //added int as argument to RecordEvent to record run number: ggilani - 15/10/14
-			}
+			RecordEvent(t, ai, run, 0, tn); //added int as argument to RecordEvent to record run number: ggilani - 15/10/14
 		}
 		if ((t > 0) && (P.DoOneGen))
 		{
@@ -176,6 +173,7 @@ void RecordEvent(double t, int ai, int run, int type, int tn) //added int as arg
 
 	//Save information to event
 #pragma omp critical (inf_event)
+	if (nEvents < P.MaxInfEvents)
 	{
 		InfEventLog[nEvents].run = run;
 		InfEventLog[nEvents].type = type;


### PR DESCRIPTION
This guarantees that `nEvents` isn't incremented to be too big by another thread, between us testing it and using it.

I've also made `nEvents` a plain int, rather than a pointer that we have to allocate.

This fixes one of the issues raise in #309.