### PR TITLE
Read/write State.cumV safely

### DIFF
--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1259,16 +1259,20 @@ void DoPlaceOpen(int i, int j, unsigned short int ts, int tn)
 void DoVacc(int ai, unsigned short int ts)
 {
 	int x, y;
+	bool cumV_OK = false;
 
 	if ((HOST_TO_BE_VACCED(ai)) || (Hosts[ai].inf < InfStat_InfectiousAlmostSymptomatic) || (Hosts[ai].inf >= InfStat_Dead_WasAsymp))
 		return;
-	if (State.cumV >= P.VaccMaxCourses)
-		return;
+#pragma omp critical (state_cumV)
+	if (State.cumV < P.VaccMaxCourses)
+	{
+		cumV_OK = true;
+		State.cumV++;
+	}
+	if (cumV_OK)
 	{
 		Hosts[ai].vacc_start_time = ts + ((unsigned short int) (P.TimeStepsPerDay * P.VaccDelayMean));
 
-#pragma omp critical (state_cumV)
-		State.cumV++;
 		if (P.VaccDosePerDay >= 0)
 		{
 #pragma omp critical (state_cumV_daily)

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1260,11 +1260,10 @@ void DoVacc(int ai, unsigned short int ts)
 {
 	int x, y;
 
+	if ((HOST_TO_BE_VACCED(ai)) || (Hosts[ai].inf < InfStat_InfectiousAlmostSymptomatic) || (Hosts[ai].inf >= InfStat_Dead_WasAsymp))
+		return;
 	if (State.cumV >= P.VaccMaxCourses)
 		return;
-	else if ((HOST_TO_BE_VACCED(ai)) || (Hosts[ai].inf < InfStat_InfectiousAlmostSymptomatic) || (Hosts[ai].inf >= InfStat_Dead_WasAsymp))
-		return;
-	else
 	{
 		Hosts[ai].vacc_start_time = ts + ((unsigned short int) (P.TimeStepsPerDay * P.VaccDelayMean));
 

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -617,7 +617,9 @@ void DoDetectedCase(int ai, double t, unsigned short int ts, int tn)
 			// wasted effort
 			bool cumV_OK;
 #pragma omp critical (state_cumV)
-			cumV_OK = State.cumV < P.VaccMaxCourses;
+			{
+				cumV_OK = State.cumV < P.VaccMaxCourses;
+			}
 			if (cumV_OK && (t < P.VaccTimeStart + P.VaccHouseholdsDuration) && ((P.VaccPropCaseHouseholds == 1) || (ranf_mt(tn) < P.VaccPropCaseHouseholds)))
 			{
 				j1 = Households[Hosts[ai].hh].FirstPerson; j2 = j1 + Households[Hosts[ai].hh].nh;

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1256,14 +1256,14 @@ void DoPlaceOpen(int i, int j, unsigned short int ts, int tn)
 	}
 }
 
-int DoVacc(int ai, unsigned short int ts)
+void DoVacc(int ai, unsigned short int ts)
 {
 	int x, y;
 
 	if (State.cumV >= P.VaccMaxCourses)
-		return 2;
+		return;
 	else if ((HOST_TO_BE_VACCED(ai)) || (Hosts[ai].inf < InfStat_InfectiousAlmostSymptomatic) || (Hosts[ai].inf >= InfStat_Dead_WasAsymp))
-		return 1;
+		return;
 	else
 	{
 		Hosts[ai].vacc_start_time = ts + ((unsigned short int) (P.TimeStepsPerDay * P.VaccDelayMean));
@@ -1292,7 +1292,6 @@ int DoVacc(int ai, unsigned short int ts)
 			}
 		}
 	}
-	return 0;
 }
 
 void DoVaccNoDelay(int ai, unsigned short int ts)

--- a/src/Update.h
+++ b/src/Update.h
@@ -14,7 +14,7 @@ void DoPlaceOpen(int, int, unsigned short int, int);
 void DoTreatCase(int, unsigned short int, int);
 void DoProph(int, unsigned short int, int);
 void DoProphNoDelay(int, unsigned short int, int, int);
-int DoVacc(int, unsigned short int);
+void DoVacc(int, unsigned short int);
 void DoVaccNoDelay(int, unsigned short int);
 //SEVERITY ANALYSIS
 void DoMild(int, int);


### PR DESCRIPTION
All the cumV reads are now also in critical sections, thus fixing one of the races identified in #309.

I don't know if the overhead of doing the `cumV` check in `DoDetectedCase` is less than work than is saved; it'll depend on how often the check succeeds. But I thought it best to leave the code in, as it's easier to remove it in the future than to re-add it.