### PR TITLE
Test State.cumVG inside the critical section

### DIFF
--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1300,7 +1300,7 @@ void DoVaccNoDelay(int ai, unsigned short int ts)
 	int x, y;
 	bool cumVG_OK = false;
 
-	if ((!HOST_TO_BE_VACCED(ai)) && (Hosts[ai].inf >= InfStat_InfectiousAlmostSymptomatic) && (Hosts[ai].inf < InfStat_Dead_WasAsymp))
+	if ((HOST_TO_BE_VACCED(ai)) || (Hosts[ai].inf < InfStat_InfectiousAlmostSymptomatic) || (Hosts[ai].inf >= InfStat_Dead_WasAsymp))
 		return;
 #pragma omp critical (state_cumVG)
 	if (State.cumVG < P.VaccMaxCourses)

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1298,12 +1298,19 @@ int DoVacc(int ai, unsigned short int ts)
 void DoVaccNoDelay(int ai, unsigned short int ts)
 {
 	int x, y;
+	bool cumVG_OK = false;
 
-	if ((State.cumVG < P.VaccMaxCourses) && (!HOST_TO_BE_VACCED(ai)) && (Hosts[ai].inf >= InfStat_InfectiousAlmostSymptomatic) && (Hosts[ai].inf < InfStat_Dead_WasAsymp))
+	if ((!HOST_TO_BE_VACCED(ai)) && (Hosts[ai].inf >= InfStat_InfectiousAlmostSymptomatic) && (Hosts[ai].inf < InfStat_Dead_WasAsymp))
+		return;
+#pragma omp critical (state_cumVG)
+	if (State.cumVG < P.VaccMaxCourses)
+	{
+		cumVG_OK = true;
+		State.cumVG++;
+	}
+	if (cumVG_OK)
 	{
 		Hosts[ai].vacc_start_time = ts;
-#pragma omp critical (state_cumVG) //changed to VG
-		State.cumVG++; //changed to VG
 		if (P.VaccDosePerDay >= 0)
 		{
 #pragma omp critical (state_cumV_daily)


### PR DESCRIPTION
This removes the race, mentioned at the end of #309, where another thread might increment it between our test and use of it.