### PR TITLE
Replace all uses of long with int32_t

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -138,10 +138,10 @@ int main(int argc, char* argv[])
 	{
 		///// Get seeds.
 		i = argc - 4;
-		sscanf(argv[i], "%li", &P.setupSeed1);
-		sscanf(argv[i + 1], "%li", &P.setupSeed2);
-		sscanf(argv[i + 2], "%li", &P.runSeed1);
-		sscanf(argv[i + 3], "%li", &P.runSeed2);
+		sscanf(argv[i], "%i", &P.setupSeed1);
+		sscanf(argv[i + 1], "%i", &P.setupSeed2);
+		sscanf(argv[i + 2], "%i", &P.runSeed1);
+		sscanf(argv[i + 3], "%i", &P.runSeed2);
 
 		///// Set parameter defaults - read them in after
 		P.PlaceCloseIndepThresh = P.LoadSaveNetwork = P.DoHeteroDensity = P.DoPeriodicBoundaries = P.DoSchoolFile = P.DoAdunitDemog = P.OutputDensFile = P.MaxNumThreads = P.DoInterventionFile = 0;
@@ -408,9 +408,9 @@ int main(int argc, char* argv[])
 		}
 		// Now that we have set P.nextRunSeed* ready for the run, we need to save the values in case
 		// we need to reinitialise the RNG after the run is interrupted.
-		long thisRunSeed1 = P.nextRunSeed1;
-		long thisRunSeed2 = P.nextRunSeed2;
-//		if (i == 0 || P.ResetSeeds) 
+		int32_t thisRunSeed1 = P.nextRunSeed1;
+		int32_t thisRunSeed2 = P.nextRunSeed2;
+//		if (i == 0 || P.ResetSeeds)
 			setall(&P.nextRunSeed1, &P.nextRunSeed2);
 
 		///// initialize model (for this realisation).
@@ -418,8 +418,8 @@ int main(int argc, char* argv[])
 		if (P.DoLoadSnapshot) LoadSnapshot();
 		while (RunModel(i))
 		{  // has been interrupted to reset holiday time. Note that this currently only happens in the first run, regardless of how many realisations are being run.
-			long tmp1 = thisRunSeed1;
-			long tmp2 = thisRunSeed2;
+			int32_t tmp1 = thisRunSeed1;
+			int32_t tmp2 = thisRunSeed2;
 			setall(&tmp1, &tmp2);  // reset random number seeds to generate same run again after calibration.
 			InitModel(i);
 		}
@@ -1309,8 +1309,8 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Only treat mixing groups within places", "%i", (void*) & (P.DoPlaceGroupTreat), 1, 1, 0)) P.DoPlaceGroupTreat = 0;
 
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Treatment trigger incidence per cell"				, "%lf", (void*) & (P.TreatCellIncThresh)			, 1, 1, 0)) P.TreatCellIncThresh			= 1000000000;
-	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Case isolation trigger incidence per cell"		, "%lf", (void*) & (P.CaseIsolation_CellIncThresh)	, 1, 1, 0)) P.CaseIsolation_CellIncThresh	= P.TreatCellIncThresh; 
-	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Household quarantine trigger incidence per cell"	, "%lf", (void*) & (P.HHQuar_CellIncThresh)			, 1, 1, 0)) P.HHQuar_CellIncThresh			= P.TreatCellIncThresh; 
+	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Case isolation trigger incidence per cell"		, "%lf", (void*) & (P.CaseIsolation_CellIncThresh)	, 1, 1, 0)) P.CaseIsolation_CellIncThresh	= P.TreatCellIncThresh;
+	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Household quarantine trigger incidence per cell"	, "%lf", (void*) & (P.HHQuar_CellIncThresh)			, 1, 1, 0)) P.HHQuar_CellIncThresh			= P.TreatCellIncThresh;
 
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Relative susceptibility of treated individual", "%lf", (void*) & (P.TreatSuscDrop), 1, 1, 0)) P.TreatSuscDrop = 1;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Relative infectiousness of treated individual", "%lf", (void*) & (P.TreatInfDrop), 1, 1, 0)) P.TreatInfDrop = 1;
@@ -4172,7 +4172,7 @@ void SaveRandomSeeds(void)
 
 	sprintf(outname, "%s.seeds.xls", OutFile);
 	if (!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open output file\n");
-	fprintf(dat, "%li\t%li\n", P.nextRunSeed1, P.nextRunSeed2);
+	fprintf(dat, "%i\t%i\n", P.nextRunSeed1, P.nextRunSeed2);
 	fclose(dat);
 }
 
@@ -4205,7 +4205,7 @@ void LoadSnapshot(void)
 {
 	FILE* dat;
 	int i, j, * CellMemberArray, * CellSuscMemberArray;
-	long l;
+	int32_t l;
 	long long CM_offset, CSM_offset;
 	double t;
 	int** Array_InvCDF;
@@ -4231,8 +4231,8 @@ void LoadSnapshot(void)
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.NCP) ERR_CRITICAL("Incorrect NCP in snapshot file.\n");
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.ncw) ERR_CRITICAL("Incorrect ncw in snapshot file.\n");
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.nch) ERR_CRITICAL("Incorrect nch in snapshot file.\n");
-	fread_big((void*)& l, sizeof(long), 1, dat); if (l != P.setupSeed1) ERR_CRITICAL("Incorrect setupSeed1 in snapshot file.\n");
-	fread_big((void*)& l, sizeof(long), 1, dat); if (l != P.setupSeed2) ERR_CRITICAL("Incorrect setupSeed2 in snapshot file.\n");
+	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed1) ERR_CRITICAL("Incorrect setupSeed1 in snapshot file.\n");
+	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed2) ERR_CRITICAL("Incorrect setupSeed2 in snapshot file.\n");
 	fread_big((void*)& t, sizeof(double), 1, dat); if (t != P.TimeStep) ERR_CRITICAL("Incorrect TimeStep in snapshot file.\n");
 	fread_big((void*) & (P.SnapshotLoadTime), sizeof(double), 1, dat);
 	P.NumSamples = 1 + (int)ceil((P.SampleTime - P.SnapshotLoadTime) / P.SampleStep);
@@ -4305,9 +4305,9 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.nch), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.setupSeed1), sizeof(long), 1, dat);
+	fwrite_big((void*) & (P.setupSeed1), sizeof(int32_t), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.setupSeed2), sizeof(long), 1, dat);
+	fwrite_big((void*) & (P.setupSeed2), sizeof(int32_t), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.TimeStep), sizeof(double), 1, dat);
 	fprintf(stderr, "## %i\n", i++);

--- a/src/Param.h
+++ b/src/Param.h
@@ -1,6 +1,8 @@
 #ifndef COVIDSIM_PARAM_H_INCLUDED_
 #define COVIDSIM_PARAM_H_INCLUDED_
 
+#include <inttypes.h>
+
 #include "Country.h"
 #include "Constants.h"
 #include "MicroCellPosition.hpp"
@@ -75,10 +77,10 @@ struct Param
 	int DoAirports, Nairports, Air_popscale, DoSchoolFile, DoRealSymptWithdrawal, CaseAbsentChildAgeCutoff, DoEarlyCaseDiagnosis, DoInterventionFile;
 	int PlaceTypeNoAirNum; // If DoAirports then this is the number of non-airport place types (< PlaceTypeNum), else == PlaceTypeNum (~ no airport places).
 	int HotelPlaceType; // If DoAirports then this is place type for hotel (>= PlaceTypeNoAirNum, < PlaceTypeNum), else == PlaceTypeNum (~ unused).
-	long setupSeed1, setupSeed2; // RNG seeds from the command line, used to initialise the RNG for setup
-	long runSeed1, runSeed2; // RNG seeds from the command line, used to initialise the RNG for running the model
-	long nextSetupSeed1, nextSetupSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for setup
-	long nextRunSeed1, nextRunSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for the model
+	int32_t setupSeed1, setupSeed2; // RNG seeds from the command line, used to initialise the RNG for setup
+	int32_t runSeed1, runSeed2; // RNG seeds from the command line, used to initialise the RNG for running the model
+	int32_t nextSetupSeed1, nextSetupSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for setup
+	int32_t nextRunSeed1, nextRunSeed2; // The next RNG seeds to use when we need to reinitialise the RNG for the model
 	int ResetSeeds,KeepSameSeeds, ResetSeedsPostIntervention, ResetSeedsFlag, TimeToResetSeeds;
 	double LongitudeCutLine; // Longitude to image earth is cut at to produce a flat map.  Default -360 degrees (effectively -180).  Use to ensure countries have a contiguous boundary
 	double SpatialBoundingBox[4], LocationInitialInfection[MAX_NUM_SEED_LOCATIONS][2], InitialInfectionsAdminUnitWeight[MAX_NUM_SEED_LOCATIONS], TimeStepsPerDay;

--- a/src/Rand.cpp
+++ b/src/Rand.cpp
@@ -10,7 +10,7 @@
 #endif
 
 /* RANDLIB static variables */
-long* Xcg1, *Xcg2;
+int32_t* Xcg1, *Xcg2;
 int **SamplingQueue = nullptr;
 
 ///////////// ********* ///////////// ********* ///////////// ********* ///////////// ********* ///////////// ********* ///////////// *********
@@ -19,7 +19,7 @@ int **SamplingQueue = nullptr;
 
 double ranf(void)
 {
-	long k, s1, s2, z;
+	int32_t k, s1, s2, z;
 	unsigned int curntg;
 
 #ifdef _OPENMP
@@ -29,11 +29,11 @@ double ranf(void)
 #endif
 	s1 = Xcg1[curntg];
 	s2 = Xcg2[curntg];
-	k = s1 / 53668L;
-	s1 = Xa1 * (s1 - k * 53668L) - k * 12211;
+	k = s1 / 53668;
+	s1 = Xa1 * (s1 - k * 53668) - k * 12211;
 	if (s1 < 0) s1 += Xm1;
-	k = s2 / 52774L;
-	s2 = Xa2 * (s2 - k * 52774L) - k * 3791;
+	k = s2 / 52774;
+	s2 = Xa2 * (s2 - k * 52774) - k * 3791;
 	if (s2 < 0) s2 += Xm2;
 	Xcg1[curntg] = s1;
 	Xcg2[curntg] = s2;
@@ -43,17 +43,17 @@ double ranf(void)
 }
 double ranf_mt(int tn)
 {
-	long k, s1, s2, z;
+	int32_t k, s1, s2, z;
 	int curntg;
 
 	curntg = CACHE_LINE_SIZE * tn;
 	s1 = Xcg1[curntg];
 	s2 = Xcg2[curntg];
-	k = s1 / 53668L;
-	s1 = Xa1 * (s1 - k * 53668L) - k * 12211;
+	k = s1 / 53668;
+	s1 = Xa1 * (s1 - k * 53668) - k * 12211;
 	if (s1 < 0) s1 += Xm1;
-	k = s2 / 52774L;
-	s2 = Xa2 * (s2 - k * 52774L) - k * 3791;
+	k = s2 / 52774;
+	s2 = Xa2 * (s2 - k * 52774) - k * 3791;
 	if (s2 < 0) s2 += Xm2;
 	Xcg1[curntg] = s1;
 	Xcg2[curntg] = s2;
@@ -62,10 +62,10 @@ double ranf_mt(int tn)
 	return ((double)z) / Xm1;
 }
 
-void setall(long *pseed1, long *pseed2)
+void setall(int32_t *pseed1, int32_t *pseed2)
 /*
 **********************************************************************
-	 void setall(long iseed1,long iseed2)
+	 void setall(int32_t iseed1,int32_t iseed2)
 			   SET ALL random number generators
 	 Sets the initial seed of generator 1 to ISEED1 and ISEED2. The
 	 initial seeds of the other generators are set accordingly, and
@@ -84,8 +84,8 @@ void setall(long *pseed1, long *pseed2)
 {
 	int g;
 
-	long iseed1 = *pseed1;
-	long iseed2 = *pseed2;
+	int32_t iseed1 = *pseed1;
+	int32_t iseed2 = *pseed2;
 
 	for (g = 0; g < MAX_NUM_THREADS; g++) {
 		*(Xcg1 + g * CACHE_LINE_SIZE) = iseed1 = mltmod(Xa1vw, iseed1, Xm1);
@@ -95,10 +95,10 @@ void setall(long *pseed1, long *pseed2)
 	*pseed1 = iseed1;
 	*pseed2 = iseed2;
 }
-long mltmod(long a, long s, long m)
+int32_t mltmod(int32_t a, int32_t s, int32_t m)
 /*
 **********************************************************************
-	 long mltmod(long a,long s,long m)
+	 int32_t mltmod(int32_t a, int32_t s, int32_t m)
 					Returns (a * s) MOD m
 	 This is a transcription from Pascal to C++ of routine
 	 MULtMod_Decompos from the paper
@@ -109,15 +109,15 @@ long mltmod(long a, long s, long m)
 **********************************************************************
 */
 {
-	const long h = 32768;
-	long a0, a1, k, p, q, qh, rh;
+	const int32_t h = 32768;
+	int32_t a0, a1, k, p, q, qh, rh;
 	/*
 		 H = 2**((b-2)/2) where b = 32 because we are using a 32 bit
 		  machine. On a different machine recompute H
 	*/
 	if (a <= 0 || a >= m || s <= 0 || s >= m) {
 		fputs(" a, m, s out of order in mltmod - ABORT!\n", stderr);
-		fprintf(stderr, " a = %12ld s = %12ld m = %12ld\n", a, s, m);
+		fprintf(stderr, " a = %12d s = %12d m = %12d\n", a, s, m);
 		fputs(" mltmod requires: 0 < a < m; 0 < s < m\n", stderr);
 		exit(1);
 	}
@@ -172,11 +172,11 @@ long mltmod(long a, long s, long m)
 	return p;
 }
 
-long ignbin(long n, double pp)
+int32_t ignbin(int32_t n, double pp)
 {
 	/*
 **********************************************************************
-	 long ignbin(long n,double pp)
+	 int32_t ignbin(int32_t n,double pp)
 					GENerate BINomial random deviate
 							  Function
 	 Generates a single random deviate from a binomial
@@ -282,8 +282,8 @@ long ignbin(long n, double pp)
 */
 /* JJV changed initial values to ridiculous values */
 	double psave = -1.0E37;
-	long nsave = -214748365;
-	long ignbin, i, ix, ix1, k, m, mp, T1;
+	int32_t nsave = -214748365;
+	int32_t ignbin, i, ix, ix1, k, m, mp, T1;
 	double al, alv, amaxp, c, f, f1, f2, ffm, fm, g, p, p1, p2, p3, p4, q, qn, r, u, v, w, w2, x, x1,
 		x2, xl, xll, xlr, xm, xnp, xnpq, xr, ynorm, z, z2;
 
@@ -305,10 +305,10 @@ long ignbin(long n, double pp)
 	nsave = n;
 	if (xnp < 30.0) goto S140;
 	ffm = xnp + p;
-	m = (long)ffm;
+	m = (int32_t)ffm;
 	fm = m;
 	xnpq = xnp * q;
-	p1 = (long)(2.195 * sqrt(xnpq) - 4.6 * q) + 0.5;
+	p1 = (int32_t)(2.195 * sqrt(xnpq) - 4.6 * q) + 0.5;
 	xm = fm + 0.5;
 	xl = xm - p1;
 	xr = xm + p1;
@@ -330,7 +330,7 @@ S30:
 		 TRIANGULAR REGION
 	*/
 	if (u > p1) goto S40;
-	ix = (long)(xm - p1 * v + u);
+	ix = (int32_t)(xm - p1 * v + u);
 	goto S170;
 S40:
 	/*
@@ -340,14 +340,14 @@ S40:
 	x = xl + (u - p1) / c;
 	v = v * c + 1.0 - std::abs(xm - x) / p1;
 	if (v > 1.0 || v <= 0.0) goto S30;
-	ix = (long)x;
+	ix = (int32_t)x;
 	goto S70;
 S50:
 	/*
 		 LEFT TAIL
 	*/
 	if (u > p3) goto S60;
-	ix = (long)(xl + log(v) / xll);
+	ix = (int32_t)(xl + log(v) / xll);
 	if (ix < 0) goto S30;
 	v *= ((u - p2) * xll);
 	goto S70;
@@ -355,7 +355,7 @@ S60:
 	/*
 		 RIGHT TAIL
 	*/
-	ix = (long)(xr - log(v) / xlr);
+	ix = (int32_t)(xr - log(v) / xlr);
 	if (ix > n) goto S30;
 	v *= ((u - p3) * xlr);
 S70:
@@ -434,10 +434,10 @@ S170:
 	ignbin = ix;
 	return ignbin;
 }
-long ignpoi(double mu)
+int32_t ignpoi(double mu)
 /*
 **********************************************************************
-	 long ignpoi(double mu)
+	 int32_t ignpoi(double mu)
 					GENerate POIsson random deviate
 							  Function
 	 Generates a single random deviate from a Poisson
@@ -500,7 +500,7 @@ long ignpoi(double mu)
 		1.0,1.0,2.0,6.0,24.0,120.0,720.0,5040.0,40320.0,362880.0
 	};
 	/* JJV added ll to the list, for Case A */
-	long ignpoi, j, k, kflag, l, ll, m;
+	int32_t ignpoi, j, k, kflag, l, ll, m;
 	double b1, b2, c, c0, c1, c2, c3, d, del, difmuk, e, fk, fx, fy, g, omega, p, p0, px, py, q, s, t, u, v, x, xx, pp[35];
 
 	if (mu < 10.0) goto S120;
@@ -515,14 +515,14 @@ long ignpoi(double mu)
 				 PROBABILITIES FK WHENEVER K >= M(MU). LL=IFIX(MU-1.1484)
 				 IS AN UPPER BOUND TO M(MU) FOR ALL MU >= 10 .
 	*/
-	ll = (long)(mu - 1.1484);
+	ll = (int32_t)(mu - 1.1484);
 
 	/*
 		 STEP N. NORMAL SAMPLE - SNORM(IR) FOR STANDARD NORMAL DEVIATE
 	*/
 	g = mu + s * snorm();
 	if (g < 0.0) goto S20;
-	ignpoi = (long)(g);
+	ignpoi = (int32_t)(g);
 	/*
 		 STEP I. IMMEDIATE ACCEPTANCE IF IGNPOI IS LARGE ENOUGH
 	*/
@@ -574,7 +574,7 @@ S50:
 	u += (u - 1.0);
 	t = 1.8 + fsign(e, u);
 	if (t <= -0.6744) goto S50;
-	ignpoi = (long)(mu + s * t);
+	ignpoi = (int32_t)(mu + s * t);
 	fk = (double)ignpoi;
 	difmuk = mu - fk;
 	/*
@@ -625,7 +625,7 @@ S120:
 		 C A S E  B. (START NEW TABLE AND CALCULATE P0 IF NECESSARY)
 		 JJV changed MUPREV assignment to initial value
 	*/
-	m = std::max(1L, (long)(mu));
+	m = std::max(INT32_C(1), (int32_t)(mu));
 	l = 0;
 	p = exp(-mu);
 	q = p0 = p;
@@ -668,10 +668,10 @@ S180:
 	ignpoi = k;
 	return ignpoi;
 }
-long ignpoi_mt(double mu, int tn)
+int32_t ignpoi_mt(double mu, int tn)
 /*
 **********************************************************************
-long ignpoi_mt(double mu)
+int32_t ignpoi_mt(double mu)
 GENerate POIsson random deviate
 Function
 Generates a single random deviate from a Poisson
@@ -734,7 +734,7 @@ SEPARATION OF CASES A AND B
 		1.0,1.0,2.0,6.0,24.0,120.0,720.0,5040.0,40320.0,362880.0
 	};
 	/* JJV added ll to the list, for Case A */
-	long ignpoi_mt, j, k, kflag, l, ll, m;
+	int32_t ignpoi_mt, j, k, kflag, l, ll, m;
 	double b1, b2, c, c0, c1, c2, c3, d, del, difmuk, e, fk, fx, fy, g, omega, p, p0, px, py, q, s, t, u, v, x, xx, pp[35];
 
 	if (mu < 10.0) goto S120;
@@ -749,14 +749,14 @@ SEPARATION OF CASES A AND B
 	PROBABILITIES FK WHENEVER K >= M(MU). LL=IFIX(MU-1.1484)
 	IS AN UPPER BOUND TO M(MU) FOR ALL MU >= 10 .
 	*/
-	ll = (long)(mu - 1.1484);
+	ll = (int32_t)(mu - 1.1484);
 
 	/*
 	STEP N. NORMAL SAMPLE - SNORM(IR) FOR STANDARD NORMAL DEVIATE
 	*/
 	g = mu + s * snorm_mt(tn);
 	if (g < 0.0) goto S20;
-	ignpoi_mt = (long)(g);
+	ignpoi_mt = (int32_t)(g);
 	/*
 	STEP I. IMMEDIATE ACCEPTANCE IF IGNPOI IS LARGE ENOUGH
 	*/
@@ -808,7 +808,7 @@ S50:
 	u += (u - 1.0);
 	t = 1.8 + fsign(e, u);
 	if (t <= -0.6744) goto S50;
-	ignpoi_mt = (long)(mu + s * t);
+	ignpoi_mt = (int32_t)(mu + s * t);
 	fk = (double)ignpoi_mt;
 	difmuk = mu - fk;
 	/*
@@ -859,7 +859,7 @@ S120:
 	C A S E  B. (START NEW TABLE AND CALCULATE P0 IF NECESSARY)
 	JJV changed MUPREV assignment to initial value
 	*/
-	m = std::max(1L, (long)(mu));
+	m = std::max(INT32_C(1), (int32_t)(mu));
 	l = 0;
 	p = exp(-mu);
 	q = p0 = p;
@@ -902,11 +902,11 @@ S180:
 	ignpoi_mt = k;
 	return ignpoi_mt;
 }
-long ignbin_mt(long n, double pp, int tn)
+int32_t ignbin_mt(int32_t n, double pp, int tn)
 {
 	/*
 **********************************************************************
-long ignbin_mt(long n,double pp)
+int32_t ignbin_mt(int32_t n,double pp)
 GENerate BINomial random deviate
 Function
 Generates a single random deviate from a binomial
@@ -1012,8 +1012,8 @@ TYPE OF ISEED SHOULD BE DICTATED BY THE UNIFORM GENERATOR
 */
 /* JJV changed initial values to ridiculous values */
 	double psave = -1.0E37;
-	long nsave = -214748365;
-	long ignbin_mt, i, ix, ix1, k, m, mp, T1;
+	int32_t nsave = -214748365;
+	int32_t ignbin_mt, i, ix, ix1, k, m, mp, T1;
 	double al, alv, amaxp, c, f, f1, f2, ffm, fm, g, p, p1, p2, p3, p4, q, qn, r, u, v, w, w2, x, x1,
 		x2, xl, xll, xlr, xm, xnp, xnpq, xr, ynorm, z, z2;
 
@@ -1035,10 +1035,10 @@ TYPE OF ISEED SHOULD BE DICTATED BY THE UNIFORM GENERATOR
 	nsave = n;
 	if (xnp < 30.0) goto S140;
 	ffm = xnp + p;
-	m = (long)ffm;
+	m = (int32_t)ffm;
 	fm = m;
 	xnpq = xnp * q;
-	p1 = (long)(2.195 * sqrt(xnpq) - 4.6 * q) + 0.5;
+	p1 = (int32_t)(2.195 * sqrt(xnpq) - 4.6 * q) + 0.5;
 	xm = fm + 0.5;
 	xl = xm - p1;
 	xr = xm + p1;
@@ -1060,7 +1060,7 @@ S30:
 	TRIANGULAR REGION
 	*/
 	if (u > p1) goto S40;
-	ix = (long)(xm - p1 * v + u);
+	ix = (int32_t)(xm - p1 * v + u);
 	goto S170;
 S40:
 	/*
@@ -1070,14 +1070,14 @@ S40:
 	x = xl + (u - p1) / c;
 	v = v * c + 1.0 - std::abs(xm - x) / p1;
 	if (v > 1.0 || v <= 0.0) goto S30;
-	ix = (long)x;
+	ix = (int32_t)x;
 	goto S70;
 S50:
 	/*
 	LEFT TAIL
 	*/
 	if (u > p3) goto S60;
-	ix = (long)(xl + log(v) / xll);
+	ix = (int32_t)(xl + log(v) / xll);
 	if (ix < 0) goto S30;
 	v *= ((u - p2) * xll);
 	goto S70;
@@ -1085,7 +1085,7 @@ S60:
 	/*
 	RIGHT TAIL
 	*/
-	ix = (long)(xr - log(v) / xlr);
+	ix = (int32_t)(xr - log(v) / xlr);
 	if (ix > n) goto S30;
 	v *= ((u - p3) * xlr);
 S70:
@@ -1197,7 +1197,7 @@ double sexpo(void)
 		0.6931472,0.9333737,0.9888778,0.9984959,0.9998293,0.9999833,0.9999986,
 		.9999999
 	};
-	long i;
+	int32_t i;
 	double sexpo, a, u, ustar, umin;
 
 	a = 0.0;
@@ -1261,7 +1261,7 @@ Q(N) = SUM(ALOG(2.0)**K/K!)    K=1,..,N ,      THE HIGHEST N
 		0.6931472,0.9333737,0.9888778,0.9984959,0.9998293,0.9999833,0.9999986,
 			.9999999
 	};
-	long i;
+	int32_t i;
 	double sexpo_mt, a, u, ustar, umin;
 
 	a = 0.0;
@@ -1348,14 +1348,14 @@ double snorm(void)
 		5.654656E-2,5.95313E-2,6.308489E-2,6.737503E-2,7.264544E-2,7.926471E-2,
 		8.781922E-2,9.930398E-2,0.11556,0.1404344,0.1836142,0.2790016,0.7010474
 	};
-	long i; //made this non-static: ggilani 27/11/14
+	int32_t i; //made this non-static: ggilani 27/11/14
 	double snorm, u, s, ustar, aa, w, y, tt; //made this non-static: ggilani 27/11/14
 	u = ranf();
 	s = 0.0;
 	if (u > 0.5) s = 1.0;
 	u += (u - s);
 	u = 32.0 * u;
-	i = (long)(u);
+	i = (int32_t)(u);
 	if (i == 32) i = 31;
 	if (i == 0) goto S100;
 	/*
@@ -1475,14 +1475,14 @@ H(K) ARE ACCORDING TO THE ABOVEMENTIONED ARTICLE
 			5.654656E-2,5.95313E-2,6.308489E-2,6.737503E-2,7.264544E-2,7.926471E-2,
 			8.781922E-2,9.930398E-2,0.11556,0.1404344,0.1836142,0.2790016,0.7010474
 	};
-	long i;
+	int32_t i;
 	double snorm_mt, u, s, ustar, aa, w, y, tt;
 	u = ranf_mt(tn);
 	s = 0.0;
 	if (u > 0.5) s = 1.0;
 	u += (u - s);
 	u = 32.0 * u;
-	i = (long)(u);
+	i = (int32_t)(u);
 	if (i == 32) i = 31;
 	if (i == 0) goto S100;
 	/*

--- a/src/Rand.h
+++ b/src/Rand.h
@@ -1,28 +1,30 @@
 #ifndef COVIDSIM_RAND_H_INCLUDED_
 #define COVIDSIM_RAND_H_INCLUDED_
 
+#include <inttypes.h>
+
 /* ranf defines */
-const long Xm1 = 2147483563;
-const long Xm2 = 2147483399;
-const long Xa1 = 40014;
-const long Xa2 = 40692;
-const long Xa1vw = 2082007225;
-const long Xa2vw = 784306273;
+const int32_t Xm1 = 2147483563;
+const int32_t Xm2 = 2147483399;
+const int32_t Xa1 = 40014;
+const int32_t Xa2 = 40692;
+const int32_t Xa1vw = 2082007225;
+const int32_t Xa2vw = 784306273;
 
 /* RANDLIB global variables */
 extern int **SamplingQueue;
-extern long* Xcg1, *Xcg2;
+extern int32_t* Xcg1, *Xcg2;
 /* RANDLIB functions */
-long ignbin(long, double);
-long ignpoi(double);
-long ignbin_mt(long, double, int);
-long ignpoi_mt(double, int);
+int32_t ignbin(int32_t, double);
+int32_t ignpoi(double);
+int32_t ignbin_mt(int32_t, double, int);
+int32_t ignpoi_mt(double, int);
 double ranf(void);
 double ranf_mt(int);
-void setall(long *, long *);
+void setall(int32_t *, int32_t *);
 double sexpo_mt(int);
 double sexpo(void);
-long mltmod(long, long, long);
+int32_t mltmod(int32_t, int32_t, int32_t);
 double snorm(void);
 double snorm_mt(int);
 double fsign(double, double);

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -405,7 +405,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 									else if (s4_scaled >= 1)	//// if place infectiousness above threshold, consider everyone in group a potential infectee...
 										n = Places[k][l].group_size[i2];
 									else				//// ... otherwise randomly sample (from binomial distribution) number of potential infectees in this place.
-										n = (int)ignbin_mt((long)Places[k][l].group_size[i2], s4_scaled, tn);
+										n = (int)ignbin_mt((int32_t)Places[k][l].group_size[i2], s4_scaled, tn);
 									if (n > 0) SampleWithoutReplacement(tn, n, Places[k][l].group_size[i2]); //// changes thread-specific SamplingQueue.
 									for (int m = 0; m < n; m++)
 									{
@@ -477,7 +477,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 									else if (s3_scaled >= 1)
 										n = Places[k][l].n;
 									else
-										n = (int)ignbin_mt((long)Places[k][l].n, s3_scaled, tn);
+										n = (int)ignbin_mt((int32_t)Places[k][l].n, s3_scaled, tn);
 									if (n > 0) SampleWithoutReplacement(tn, n, Places[k][l].n);
 									for (int m = 0; m < n; m++)
 									{


### PR DESCRIPTION
This should make network files portable between LLP64 (e.g. Windows) and LP64 (e.g macOS, Linux) platforms.

This is the simplest change possible.  It would be worth reviewing all uses of int32_t to see whether they can/should be uint32_t.

A grep of long in the code should now only find "long long" and the use of the characters "long" in comments.