### PR TITLE
Fix VS Builds - relocate Clang library include

### DIFF
--- a/covid-sim.vcxproj
+++ b/covid-sim.vcxproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -75,16 +75,16 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>DO_OMP_PARALLEL;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <OpenMPSupport>false</OpenMPSupport>
+      <OpenMPSupport>true</OpenMPSupport>
       <AdditionalOptions>/Zc:twoPhase- -openmp %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>Default</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Gdiplus.lib;Vfw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Gdiplus.lib;Vfw32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Profile>true</Profile>
       <AdditionalLibraryDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\Llvm\x64\lib</AdditionalLibraryDirectories>
     </Link>

--- a/src/CovidSim.h
+++ b/src/CovidSim.h
@@ -6,8 +6,10 @@
 // that causes VS/Intel compilers to fail to build if libomp.lib is
 // not found. The following should include the lib file only on Clang.
 
-#ifdef __clang__
+#ifdef _WIN32
+  #ifdef __clang__
 #pragma comment(lib, "libomp.lib")
+  #endif
 #endif
 
 #include "MachineDefines.h"

--- a/src/CovidSim.h
+++ b/src/CovidSim.h
@@ -1,6 +1,15 @@
 #ifndef COVIDSIM_COVIDSIM_H_INCLUDED_
 #define COVIDSIM_COVIDSIM_H_INCLUDED_
 
+// Compiling with Clang from VS requires libomp.lib to be included in
+// Project, Properties, Input, Additional Dependencies, however
+// that causes VS/Intel compilers to fail to build if libomp.lib is
+// not found. The following should include the lib file only on Clang.
+
+#ifdef __clang__
+#pragma comment(lib, "libomp.lib")
+#endif
+
 #include "MachineDefines.h"
 
 #include <limits.h>


### PR DESCRIPTION
In Visual Studio "Project Properties, Linker, Additional dependencies" is not compiler specific. Clang needs `libomp.lib` to be declared, but with that setting, the MS/Intel compilers will fail to build if Clang is not installed and that library is not found.

This PR moves the dependency for libomp.lib into a #pragma in CovidSim.h, surrounded by #ifdef for __clang__ and _WIN32