### PR TITLE
Add OpenMP instruction for building on MacOS

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -15,6 +15,11 @@ cmake ..
 make
 ```
 
+On MacOS, make sure you have OpenMP installed:
+```sh
+brew install libomp
+```
+
 ### Testing
 
 Once `make` has completed use:


### PR DESCRIPTION
Otherwise, you'll get a:
```
Make Error at /usr/local/Cellar/cmake/3.17.3/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:164 (message):
  Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES)
```