### PR TITLE
Remove DomainSize comments

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -17,10 +17,7 @@ enum BitmapFormats
 /// Size of spatial domain in various units
 struct DomainSize
 {
-	/// The width
 	double width_;
-
-	/// The height
 	double height_;
 };
 


### PR DESCRIPTION
They aren't any more useful than the variable names.