### PR TITLE
Buffer changes to host.absent_start|stop_time, and commit single-threaded

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2807,7 +2807,10 @@ void InitModel(int run) // passing run number so we can save run number in the i
 	{
 		for (int j = 0; j < MAX_NUM_THREADS; j++)	StateT[i].n_queue[j] = 0;
 		for (int j = 0; j < P.PlaceTypeNum; j++)	StateT[i].np_queue[j] = 0;
+		StateT[i].host_closure_queue_size = 0;
 	}
+
+	
 	if (DoInitUpdateProbs)
 	{
 		UpdateProbs(0);
@@ -2969,6 +2972,11 @@ void SeedInfection(double t, int* nsi, int rf, int run) //adding run number to p
 			}
 		}
 	}
+
+	// Is there a possibility that place closure can happen in the DoInfect calls above?
+	// Not sure - but to play safe...
+	UpdateHostClosure();
+
 	if (m > 0) fprintf(stderr, "### Seeding error ###\n");
 }
 
@@ -3079,6 +3087,7 @@ int RunModel(int run) //added run number as parameter
 									l = (int)(((double)P.PopSize) * ranf()); //// choose person l randomly from entire population. (but change l if while condition not satisfied?)
 								} while ((abs(Hosts[l].inf) == InfStat_Dead) || (ranf() > P.FalsePositiveAgeRate[HOST_AGE_GROUP(l)]));
 								DoFalseCase(l, t, ts, 0);
+								UpdateHostClosure();
 							}
 						}
 					}

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2973,10 +2973,6 @@ void SeedInfection(double t, int* nsi, int rf, int run) //adding run number to p
 		}
 	}
 
-	// Is there a possibility that place closure can happen in the DoInfect calls above?
-	// Not sure - but to play safe...
-	UpdateHostClosure();
-
 	if (m > 0) fprintf(stderr, "### Seeding error ###\n");
 }
 
@@ -3087,7 +3083,6 @@ int RunModel(int run) //added run number as parameter
 									l = (int)(((double)P.PopSize) * ranf()); //// choose person l randomly from entire population. (but change l if while condition not satisfied?)
 								} while ((abs(Hosts[l].inf) == InfStat_Dead) || (ranf() > P.FalsePositiveAgeRate[HOST_AGE_GROUP(l)]));
 								DoFalseCase(l, t, ts, 0);
-								UpdateHostClosure();
 							}
 						}
 					}
@@ -3106,7 +3101,9 @@ int RunModel(int run) //added run number as parameter
 						if ((!fs2) && (State.L + State.I == 0) && (P.FalsePositivePerCapitaIncidence == 0)) { if ((ir == 0) && (((int)t) > P.DurImportTimeProfile)) fs = 0; }
 					}
 					if (P.DoAirports) TravelReturnSweep(t);
+					UpdateHostClosure();
 				}
+
 				t += P.TimeStep;
 				if (P.DoDeath) P.ts_age++;
 				if ((P.DoSaveSnapshot) && (t <= P.SnapshotSaveTime) && (t + P.TimeStep > P.SnapshotSaveTime)) SaveSnapshot();

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2809,8 +2809,6 @@ void InitModel(int run) // passing run number so we can save run number in the i
 		for (int j = 0; j < P.PlaceTypeNum; j++)	StateT[i].np_queue[j] = 0;
 		StateT[i].host_closure_queue_size = 0;
 	}
-
-	
 	if (DoInitUpdateProbs)
 	{
 		UpdateProbs(0);
@@ -2972,7 +2970,6 @@ void SeedInfection(double t, int* nsi, int rf, int run) //adding run number to p
 			}
 		}
 	}
-
 	if (m > 0) fprintf(stderr, "### Seeding error ###\n");
 }
 
@@ -3103,7 +3100,6 @@ int RunModel(int run) //added run number as parameter
 					if (P.DoAirports) TravelReturnSweep(t);
 					UpdateHostClosure();
 				}
-
 				t += P.TimeStep;
 				if (P.DoDeath) P.ts_age++;
 				if ((P.DoSaveSnapshot) && (t <= P.SnapshotSaveTime) && (t + P.TimeStep > P.SnapshotSaveTime)) SaveSnapshot();

--- a/src/Model.h
+++ b/src/Model.h
@@ -91,6 +91,17 @@ struct ContactEvent
 };
 
 /**
+ * @brief Apply place closure effects to household in a clearer way, to avoid *the appearance* of a data race.
+ *
+ */
+struct HostClosure
+{
+	int host_index;
+	unsigned short start_time;
+	unsigned short stop_time;
+};
+
+/**
  * @brief The global state of the model.
  *
  * TODO: Detailed explanation.
@@ -110,6 +121,8 @@ struct PopVar
 	int cumItype[INFECT_TYPE_MASK], cumI_keyworker[2], cumC_keyworker[2], cumT_keyworker[2];
 	Infection *inf_queue[MAX_NUM_THREADS]; // the queue (i.e. list) of infections. 1st index is thread, 2nd is person.
 	int n_queue[MAX_NUM_THREADS]; 	// number of infections in inf_queue
+	HostClosure *host_closure_queue;  // When places close, host absenteeism times get set within threaded loop.
+	int host_closure_queue_size; // Number of hosts in a timestep to set min/max absenteeism times for. 
 	int* p_queue[NUM_PLACE_TYPES], *pg_queue[NUM_PLACE_TYPES], np_queue[NUM_PLACE_TYPES];		// np_queue is number of places in place queue (by place type), p_queue, and pg_queue is the actual place and place-group queue (i.e. list) of places. 1st index is place type, 2nd is place.
 	int NumPlacesClosed[NUM_PLACE_TYPES], n_mvacc, mvacc_cum;
 	float* cell_inf;  //// List of spatial infectiousnesses by person within cell.

--- a/src/Model.h
+++ b/src/Model.h
@@ -91,7 +91,7 @@ struct ContactEvent
 };
 
 /**
- * @brief Apply place closure effects to household in a clearer way, to avoid *the appearance* of a data race.
+ * @brief Apply place closure effects to household in a thread-safe way.
  *
  */
 struct HostClosure
@@ -121,8 +121,8 @@ struct PopVar
 	int cumItype[INFECT_TYPE_MASK], cumI_keyworker[2], cumC_keyworker[2], cumT_keyworker[2];
 	Infection *inf_queue[MAX_NUM_THREADS]; // the queue (i.e. list) of infections. 1st index is thread, 2nd is person.
 	int n_queue[MAX_NUM_THREADS]; 	// number of infections in inf_queue
-	HostClosure *host_closure_queue;  // When places close, host absenteeism times get set within threaded loop.
-	int host_closure_queue_size; // Number of hosts in a timestep to set min/max absenteeism times for. 
+	HostClosure *host_closure_queue;  // When places close, buffer host index, and closure times here.
+	int host_closure_queue_size; // Number of host closures in host_closure_queue.
 	int* p_queue[NUM_PLACE_TYPES], *pg_queue[NUM_PLACE_TYPES], np_queue[NUM_PLACE_TYPES];		// np_queue is number of places in place queue (by place type), p_queue, and pg_queue is the actual place and place-group queue (i.e. list) of places. 1st index is place type, 2nd is place.
 	int NumPlacesClosed[NUM_PLACE_TYPES], n_mvacc, mvacc_cum;
 	float* cell_inf;  //// List of spatial infectiousnesses by person within cell.

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -2481,7 +2481,8 @@ void LoadPeopleToPlaces(char* NetworkFile)
 	fread_big(&s2, sizeof(int32_t), 1, dat);
 	if (i != npt) ERR_CRITICAL("Number of place types does not match saved value\n");
 	if (j != P.PopSize) ERR_CRITICAL("Population size does not match saved value\n");
-	if ((s1 != P.setupSeed1) || (s2 != P.setupSeed2)) {
+	if ((s1 != P.setupSeed1) || (s2 != P.setupSeed2))
+	{
 		ERR_CRITICAL_FMT("Random number seeds do not match saved values: %" PRId32 " != %" PRId32 " || %" PRId32 " != %" PRId32 "\n", s1, P.setupSeed1, s2, P.setupSeed2);
 	}
 	k = (P.PopSize + 999999) / 1000000;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -2482,8 +2482,8 @@ void LoadPeopleToPlaces(char* NetworkFile)
 	if (i != npt) ERR_CRITICAL("Number of place types does not match saved value\n");
 	if (j != P.PopSize) ERR_CRITICAL("Population size does not match saved value\n");
 	if ((s1 != P.setupSeed1) || (s2 != P.setupSeed2)) {
-    ERR_CRITICAL_FMT("Random number seeds do not match saved values: %" PRId32 " != %" PRId32 " || %" PRId32 " != %" PRId32 "\n", s1, P.setupSeed1, s2, P.setupSeed2);
-  }
+		ERR_CRITICAL_FMT("Random number seeds do not match saved values: %" PRId32 " != %" PRId32 " || %" PRId32 " != %" PRId32 "\n", s1, P.setupSeed1, s2, P.setupSeed2);
+	}
 	k = (P.PopSize + 999999) / 1000000;
 	for (i = 0; i < P.PopSize; i++)
 		for (j = 0; j < P.PlaceTypeNum; j++)

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1454,6 +1454,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		for (int k = 0; k < P.NumThreads; k++)
 			if (!(StateT[i].inf_queue[k] = (Infection*)malloc(P.InfQueuePeakLength * sizeof(Infection)))) ERR_CRITICAL("Unable to allocate state storage\n");
 		if (!(StateT[i].cell_inf = (float*)malloc((l + 1) * sizeof(float)))) ERR_CRITICAL("Unable to allocate state storage\n");
+		if (!(StateT[i].host_closure_queue = (HostClosure*)malloc(P.InfQueuePeakLength * sizeof(HostClosure)))) ERR_CRITICAL("Unable to allocate state storage\n");
 	}
 
 	//set up queues and storage for digital contact tracing

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -742,6 +742,8 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 			StateT[k].n_queue[j] = 0;
 		}
 	}
+
+	UpdateHostClosure();
 }
 
 void IncubRecoverySweep(double t, int run)
@@ -840,6 +842,7 @@ void IncubRecoverySweep(double t, int run)
 				}
 			}
 		}
+	UpdateHostClosure();
 }
 
 
@@ -1179,6 +1182,8 @@ void DigitalContactTracingSweep(double t)
 			}
 		}
 	}
+
+	UpdateHostClosure();
 }
 
 int TreatSweep(double t)
@@ -1761,7 +1766,10 @@ int TreatSweep(double t)
 						} while (f3);
 					}
 
-			}
+			} // End of bs loop, tn loop, and prgama.
+
+		UpdateHostClosure();
+
 		for (int i = 0; i < P.NumThreads; i++)
 		{
 			State.cumT += StateT[i].cumT;

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -1766,7 +1766,7 @@ int TreatSweep(double t)
 						} while (f3);
 					}
 
-			} // End of bs loop, tn loop, and prgama.
+			} // End of bs loop, tn loop, and pragma.
 
 		UpdateHostClosure();
 

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -1762,7 +1762,6 @@ int TreatSweep(double t)
 					}
 
 			} // End of bs loop, tn loop, and pragma.
-
 		for (int i = 0; i < P.NumThreads; i++)
 		{
 			State.cumT += StateT[i].cumT;

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -742,8 +742,6 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 			StateT[k].n_queue[j] = 0;
 		}
 	}
-
-	UpdateHostClosure();
 }
 
 void IncubRecoverySweep(double t, int run)
@@ -842,7 +840,6 @@ void IncubRecoverySweep(double t, int run)
 				}
 			}
 		}
-	UpdateHostClosure();
 }
 
 
@@ -1182,8 +1179,6 @@ void DigitalContactTracingSweep(double t)
 			}
 		}
 	}
-
-	UpdateHostClosure();
 }
 
 int TreatSweep(double t)
@@ -1767,8 +1762,6 @@ int TreatSweep(double t)
 					}
 
 			} // End of bs loop, tn loop, and pragma.
-
-		UpdateHostClosure();
 
 		for (int i = 0; i < P.NumThreads; i++)
 		{

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1254,7 +1254,7 @@ void DoPlaceClose(int i, int j, unsigned short int ts, int tn, int DoAnyway)
 void UpdateHostClosure() {
 	int omp_thread_no = 0;
 
-#pragma omp parallel for private(omp_thread_no) default(none) schedule(static, 1)
+#pragma omp parallel for private(omp_thread_no) shared(P, StateT, Hosts) default(none) schedule(static, 1)
 	for (omp_thread_no = 0; omp_thread_no < P.NumThreads; omp_thread_no++)
 	{
 		for (int hcq_thread_no = 0; hcq_thread_no < P.NumThreads; hcq_thread_no++)

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1252,7 +1252,7 @@ void DoPlaceClose(int i, int j, unsigned short int ts, int tn, int DoAnyway)
 }
 
 void UpdateHostClosure() {
-    // Single-threaded here, because the same host index might come up in
+	// Single-threaded here, because the same host index might come up in
 	// different threads. (Which is the point of this buffered update...)
 
 	for (int thread_no = 0; thread_no < P.NumThreads; thread_no++) {

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1252,21 +1252,31 @@ void DoPlaceClose(int i, int j, unsigned short int ts, int tn, int DoAnyway)
 }
 
 void UpdateHostClosure() {
-	// Single-threaded here, because the same host index might come up in
-	// different threads. (Which is the point of this buffered update...)
+	int omp_thread_no = 0;
 
-	for (int thread_no = 0; thread_no < P.NumThreads; thread_no++) {
-		int count = StateT[thread_no].host_closure_queue_size;
-		for (int host = 0; host < count; host++) {
-			int host_index = StateT[thread_no].host_closure_queue[host].host_index;
-			unsigned short t_start = StateT[thread_no].host_closure_queue[host].start_time;
-			unsigned short t_stop = StateT[thread_no].host_closure_queue[host].stop_time;
-
-			if (Hosts[host_index].absent_start_time > t_start) Hosts[host_index].absent_start_time = t_start;
-			if (Hosts[host_index].absent_stop_time < t_stop) Hosts[host_index].absent_stop_time = t_stop;
+#pragma omp parallel for private(omp_thread_no) default(none) schedule(static, 1)
+	for (omp_thread_no = 0; omp_thread_no < P.NumThreads; omp_thread_no++)
+	{
+		for (int hcq_thread_no = 0; hcq_thread_no < P.NumThreads; hcq_thread_no++)
+		{
+			for (int host = 0; host < StateT[hcq_thread_no].host_closure_queue_size; host++)
+			{
+				int host_index = StateT[hcq_thread_no].host_closure_queue[host].host_index;
+				if (host_index % P.NumThreads == omp_thread_no)
+				{
+					unsigned short t_start = StateT[hcq_thread_no].host_closure_queue[host].start_time;
+					unsigned short t_stop = StateT[hcq_thread_no].host_closure_queue[host].stop_time;
+					if (Hosts[host_index].absent_start_time > t_start) Hosts[host_index].absent_start_time = t_start;
+					if (Hosts[host_index].absent_stop_time < t_stop) Hosts[host_index].absent_stop_time = t_stop;
+				}
+			}
 		}
-		StateT[thread_no].host_closure_queue_size = 0;
 	}
+
+	// Implicit barrier happens at end of #pragma omp parallel, so it's now safe to reset queue sizes
+
+	for (int thread_no = 0; thread_no < P.NumThreads; thread_no++)
+		StateT[thread_no].host_closure_queue_size = 0;
 }
 
 void DoPlaceOpen(int i, int j, unsigned short int ts, int tn)

--- a/src/Update.h
+++ b/src/Update.h
@@ -10,6 +10,7 @@ void DoFalseCase(int, double, unsigned short int, int);
 void DoRecover(int, int, int); //added int as argument to record run number: ggilani - 23/10/14. Added thread number to record Severity categories in StateT.
 void DoDeath(int, int, int); //added int as argument to record run number: ggilani - 23/10/14
 void DoPlaceClose(int, int, unsigned short int, int, int);
+void UpdateHostClosure();
 void DoPlaceOpen(int, int, unsigned short int, int);
 void DoTreatCase(int, unsigned short int, int);
 void DoProph(int, unsigned short int, int);


### PR DESCRIPTION
Intel Inspector reported a data race on the middle two if statements Update.cpp:1229, 1230 on current master, in threaded `DoPlaceClose`)- data races on which thread gets to those particular lines first; no other lines involved.
```
if ((HOST_AGE_YEAR(l) >= P.CaseAbsentChildAgeCutoff) && (abs(Hosts[l].inf) != InfStat_Dead))
{
  if (Hosts[l].absent_start_time > t_start) Hosts[l].absent_start_time = t_start;
  if (Hosts[l].absent_stop_time < t_stop) Hosts[l].absent_stop_time = t_stop;
  StateT[tn].cumAPA++;
  f = 1;
}
```
The reason is a rare case where two schools close, and a child from each school belong to the same household, and each thread wants to update the absentee timings simultaneously. As the two instructions are effectively max/min, the results will not be affected by this change, and neither is master non-deterministic. Yet, it is probably helpful to remove the warning from Intel Inspector and thread this anyway. 

I have buffered these changes in a threaded-array, see `host_closure_queue` and `host_closure_queue_size` in Model.h, which are put in `StateT[tn]`. I then replace the above lines in `DoPlaceClosure` with thread-safe lines, and I call a new function `UpdateHostClosure()` to flush those changes, at the end of each surrounding thread-loop where `DoPlaceClosure` might be called. 

I believe since t_start and t_stop are a few timesteps in the future compared to the current timestep, the effects of the change do not need to be in place immediately (and we would see more warnings from Intel Inspector if that were necessary I think).