### PR TITLE
Rename some parameters in Param.h

### DIFF
--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -58,15 +58,15 @@ void CaptureBitmap()
 			}
 		}
 		logMaxPop = log(1.001 * (double)maxPop);
-		for (int i = 0; i < P.NMC; i++)
+		for (int i = 0; i < P.microcells_count; i++)
 			if (Mcells[i].n > 0)
 			{
 				f = 0;
-				if ((i < P.NMC - 1) && (i / P.get_number_of_micro_cells_high() == (i + 1) / P.get_number_of_micro_cells_high()) && (Mcells[i + 1].n > 0) && ((Mcells[i].country != Mcells[i + 1].country)
-					|| ((P.DoAdunitBoundaryOutput) && ((AdUnits[Mcells[i].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor != (AdUnits[Mcells[i + 1].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor)))) f = 1;
+				if ((i < P.microcells_count - 1) && (i / P.get_number_of_micro_cells_high() == (i + 1) / P.get_number_of_micro_cells_high()) && (Mcells[i + 1].n > 0) && ((Mcells[i].country != Mcells[i + 1].country)
+                                                                                                                                                                          || ((P.DoAdunitBoundaryOutput) && ((AdUnits[Mcells[i].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor != (AdUnits[Mcells[i + 1].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor)))) f = 1;
 				if ((i > 0) && (i / P.get_number_of_micro_cells_high() == (i - 1) / P.get_number_of_micro_cells_high()) && (Mcells[i - 1].n > 0) && (Mcells[i].country != Mcells[i - 1].country)) f = 1;
-				if ((i < P.NMC - P.get_number_of_micro_cells_high()) && (Mcells[i + P.get_number_of_micro_cells_high()].n > 0) && ((Mcells[i].country != Mcells[i + P.get_number_of_micro_cells_high()].country)
-					|| ((P.DoAdunitBoundaryOutput) && ((AdUnits[Mcells[i].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor != (AdUnits[Mcells[i + P.get_number_of_micro_cells_high()].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor)))) f = 1;
+				if ((i < P.microcells_count - P.get_number_of_micro_cells_high()) && (Mcells[i + P.get_number_of_micro_cells_high()].n > 0) && ((Mcells[i].country != Mcells[i + P.get_number_of_micro_cells_high()].country)
+                                                                                                                                                || ((P.DoAdunitBoundaryOutput) && ((AdUnits[Mcells[i].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor != (AdUnits[Mcells[i + P.get_number_of_micro_cells_high()].adunit].id % P.AdunitLevel1Mask) / P.AdunitBitmapDivisor)))) f = 1;
 				if ((i >= P.get_number_of_micro_cells_high()) && (Mcells[i - P.get_number_of_micro_cells_high()].n > 0) && (Mcells[i].country != Mcells[i - P.get_number_of_micro_cells_high()].country)) f = 1;
 				if (f)
 				{

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -43,7 +43,7 @@ void CaptureBitmap()
 		fst = 0;
 		int32_t maxPop = 0;
 		for (int i = 0; i < mi; i++) bmPopulation[i] = 0;
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			x = ((int)(Households[Hosts[i].hh].loc_x * P.scalex)) - P.bminx;
 			y = ((int)(Households[Hosts[i].hh].loc_y * P.scaley)) - P.bminy;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -503,10 +503,10 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Sampling timestep", "%lf", (void*)&(P.SampleStep), 1, 1, 0);
 	if (P.TimeStep > P.SampleStep) ERR_CRITICAL("Update step must be smaller than sampling step\n");
 	t = ceil(P.SampleStep / P.TimeStep - 1e-6);
-	P.UpdatesPerSample = (int)t;
+	P.time_steps_between_samples = (int)t;
 	P.TimeStep = P.SampleStep / t;
 	P.TimeStepsPerDay = ceil(1.0 / P.TimeStep - 1e-6);
-	fprintf(stderr, "Update step = %lf\nSampling step = %lf\nUpdates per sample=%i\nTimeStepsPerDay=%lf\n", P.TimeStep, P.SampleStep, P.UpdatesPerSample, P.TimeStepsPerDay);
+	fprintf(stderr, "Update step = %lf\nSampling step = %lf\nUpdates per sample=%i\nTimeStepsPerDay=%lf\n", P.TimeStep, P.SampleStep, P.time_steps_between_samples, P.TimeStepsPerDay);
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Sampling time", "%lf", (void*)&(P.SampleTime), 1, 1, 0);
 	P.NumSamples = 1 + (int)ceil(P.SampleTime / P.SampleStep);
 	GetInputParameter(PreParamFile_dat, AdminFile_dat, "Population size", "%i", (void*)&(P.population_size), 1, 1, 0);
@@ -3038,7 +3038,7 @@ int RunModel(int run) //added run number as parameter
 			//Only run to a certain number of infections: ggilani 28/10/14
 			if (P.LimitNumInfections) continueEvents = (State.cumI < P.MaxNumInfections);
 
-			for (j = 0; ((j < P.UpdatesPerSample) && (!InterruptRun) && (continueEvents)); j++)
+			for (j = 0; ((j < P.time_steps_between_samples) && (!InterruptRun) && (continueEvents)); j++)
 			{
 				ts = (unsigned short int) (P.TimeStepsPerDay * t);
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -385,13 +385,13 @@ int main(int argc, char* argv[])
 	//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 
 
-	P.actual_extinct_realisations_count = P.NRactNE = 0;
-	for (i = 0; (i < P.realisations_count) && (P.NRactNE < P.non_extinct_realisations_count) ; i++)
+	P.actual_extinct_realisations_count = P.actual_non_extinct_realisations_count = 0;
+	for (i = 0; (i < P.realisations_count) && (P.actual_non_extinct_realisations_count < P.non_extinct_realisations_count) ; i++)
 	{
 		if (P.realisations_count > 1)
 		{
 			sprintf(OutFile, "%s.%i", OutFileBase, i);
-			fprintf(stderr, "Realisation %i of %i  (time=%lf nr_ne=%i)\n", i + 1, P.realisations_count, ((double)(clock() - cl)) / CLOCKS_PER_SEC, P.NRactNE);
+			fprintf(stderr, "Realisation %i of %i  (time=%lf nr_ne=%i)\n", i + 1, P.realisations_count, ((double)(clock() - cl)) / CLOCKS_PER_SEC, P.actual_non_extinct_realisations_count);
 		}
 		P.StopCalibration = P.ModelCalibIteration = 0;  // needed for calibration to work for multiple realisations
 		P.PreControlClusterIdHolOffset = 0; // needed for calibration to work for multiple realisations
@@ -460,7 +460,7 @@ int main(int argc, char* argv[])
 		SaveOriginDestMatrix();
 	}
 
-	P.actual_realisations_count = P.NRactNE;
+	P.actual_realisations_count = P.actual_non_extinct_realisations_count;
 	TSMean = TSMeanNE; TSVar = TSVarNE;
 	if ((P.DoRecordInfEvents) && (P.RecordInfEventsPerRun == 0))
 	{
@@ -475,7 +475,7 @@ int main(int argc, char* argv[])
 
 	Bitmap_Finalise();
 
-	fprintf(stderr, "Extinction in %i out of %i runs\n", P.actual_extinct_realisations_count, P.NRactNE + P.actual_extinct_realisations_count);
+	fprintf(stderr, "Extinction in %i out of %i runs\n", P.actual_extinct_realisations_count, P.actual_non_extinct_realisations_count + P.actual_extinct_realisations_count);
 	fprintf(stderr, "Model ran in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
 	fprintf(stderr, "Model finished\n");
 }
@@ -3603,7 +3603,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 	FILE* dat;
 	char outname[1024];
 
-	c = 1 / ((double)(P.actual_extinct_realisations_count + P.NRactNE));
+	c = 1 / ((double)(P.actual_extinct_realisations_count + P.actual_non_extinct_realisations_count));
 
 	if (P.OutputNonSeverity)
 	{
@@ -3611,7 +3611,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		if(!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open output file\n");
 		//// set colnames
 		fprintf(dat, "t\tS\tL\tI\tR\tD\tincI\tincR\tincD\tincC\tincDC\tincTC\tcumT\tcumTmax\tcumTP\tcumV\tcumVmax\tExtinct\trmsRad\tmaxRad\tvS\tvI\tvR\tvD\tvincI\tvincR\tvincFC\tvincC\tvincDC\tvincTC\tvrmsRad\tvmaxRad\t\t%i\t%i\t%.10f\t%.10f\t%.10f\t\t%.10f\t%.10f\t%.10f\t%.10f\n",
-				P.NRactNE, P.actual_extinct_realisations_count, P.R0household, P.R0places, P.R0spatial, c * PeakHeightSum, c * PeakHeightSS - c * c * PeakHeightSum * PeakHeightSum, c * PeakTimeSum, c * PeakTimeSS - c * c * PeakTimeSum * PeakTimeSum);
+				P.actual_non_extinct_realisations_count, P.actual_extinct_realisations_count, P.R0household, P.R0places, P.R0spatial, c * PeakHeightSum, c * PeakHeightSS - c * c * PeakHeightSum * PeakHeightSum, c * PeakTimeSum, c * PeakTimeSS - c * c * PeakTimeSum * PeakTimeSum);
 		c = 1 / ((double)P.actual_realisations_count);
 
 		//// populate table
@@ -5417,7 +5417,7 @@ void RecordInfTypes(void)
 	}
 	else
 	{
-		TSMean = TSMeanNE; TSVar = TSVarNE; P.NRactNE++;
+		TSMean = TSMeanNE; TSVar = TSVarNE; P.actual_non_extinct_realisations_count++;
 	}
 	lc = -k;
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -1266,7 +1266,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = 1.0;
 	}
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Grid size", "%lf", (void*) & (P.in_cells_.width_), 1, 1, 0)) P.in_cells_.width_ = 1.0 / 120.0;
-	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Use long/lat coord system", "%i", (void*) & (P.DoUTM_coords), 1, 1, 0)) P.DoUTM_coords = 1;
+	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Use long/lat coord system", "%i", (void*) & (P.use_utm_coordinate_system), 1, 1, 0)) P.use_utm_coordinate_system = 1;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Bitmap scale", "%lf", (void*) & (P.BitmapScale), 1, 1, 0)) P.BitmapScale = 1.0;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Bitmap y:x aspect scaling", "%lf", (void*) & (P.BitmapAspectScale), 1, 1, 0)) P.BitmapAspectScale = 1.0;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Bitmap movie frame interval", "%i", (void*) & (P.BitmapMovieFrame), 1, 1, 0)) P.BitmapMovieFrame = 250;
@@ -2081,7 +2081,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	P.usCaseIsolationDuration = ((unsigned short int) (P.CaseIsolationDuration * P.TimeStepsPerDay));
 	P.usCaseAbsenteeismDuration = ((unsigned short int) (P.CaseAbsenteeismDuration * P.TimeStepsPerDay));
 	P.usCaseAbsenteeismDelay = ((unsigned short int) (P.CaseAbsenteeismDelay * P.TimeStepsPerDay));
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 	{
 		for (i = 0; i <= 1000; i++)
 		{

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -355,7 +355,7 @@ int main(int argc, char* argv[])
 	//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 
 
-	P.NumRealisations = GotNR;
+	P.realisations_count = GotNR;
 	ReadParams(ParamFile, PreParamFile);
 	if (GotScF) P.DoSchoolFile = 1;
 	if (P.DoAirports)
@@ -386,12 +386,12 @@ int main(int argc, char* argv[])
 
 
 	P.NRactE = P.NRactNE = 0;
-	for (i = 0; (i < P.NumRealisations) && (P.NRactNE < P.NumNonExtinctRealisations) ; i++)
+	for (i = 0; (i < P.realisations_count) && (P.NRactNE < P.NumNonExtinctRealisations) ; i++)
 	{
-		if (P.NumRealisations > 1)
+		if (P.realisations_count > 1)
 		{
 			sprintf(OutFile, "%s.%i", OutFileBase, i);
-			fprintf(stderr, "Realisation %i of %i  (time=%lf nr_ne=%i)\n", i + 1, P.NumRealisations,((double)(clock() - cl)) / CLOCKS_PER_SEC, P.NRactNE);
+			fprintf(stderr, "Realisation %i of %i  (time=%lf nr_ne=%i)\n", i + 1, P.realisations_count, ((double)(clock() - cl)) / CLOCKS_PER_SEC, P.NRactNE);
 		}
 		P.StopCalibration = P.ModelCalibIteration = 0;  // needed for calibration to work for multiple realisations
 		P.PreControlClusterIdHolOffset = 0; // needed for calibration to work for multiple realisations
@@ -510,13 +510,13 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Sampling time", "%lf", (void*)&(P.SampleTime), 1, 1, 0);
 	P.NumSamples = 1 + (int)ceil(P.SampleTime / P.SampleStep);
 	GetInputParameter(PreParamFile_dat, AdminFile_dat, "Population size", "%i", (void*)&(P.population_size), 1, 1, 0);
-	if (P.NumRealisations == 0)
+	if (P.realisations_count == 0)
 		{
-		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of realisations", "%i", (void*)&(P.NumRealisations), 1, 1, 0);
-		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Number of non-extinct realisations", "%i", (void*)&(P.NumNonExtinctRealisations), 1, 1, 0)) P.NumNonExtinctRealisations = P.NumRealisations;
+		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of realisations", "%i", (void*)&(P.realisations_count), 1, 1, 0);
+		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Number of non-extinct realisations", "%i", (void*)&(P.NumNonExtinctRealisations), 1, 1, 0)) P.NumNonExtinctRealisations = P.realisations_count;
 		}
 	else
-		P.NumNonExtinctRealisations = P.NumRealisations;
+		P.NumNonExtinctRealisations = P.realisations_count;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Maximum number of cases defining small outbreak", "%i", (void*) & (P.SmallEpidemicCases), 1, 1, 0)) P.SmallEpidemicCases = -1;
 
 	P.NC = -1;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -519,7 +519,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 		P.non_extinct_realisations_count = P.realisations_count;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Maximum number of cases defining small outbreak", "%i", (void*) & (P.SmallEpidemicCases), 1, 1, 0)) P.SmallEpidemicCases = -1;
 
-	P.NC = -1;
+	P.cells_count = -1;
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of micro-cells per spatial cell width", "%i", (void*) & (P.NMCL), 1, 1, 0);
 	//added parameter to reset seeds after every run
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Reset seeds for every run", "%i", (void*) & (P.ResetSeeds), 1, 1, 0)) P.ResetSeeds = 0;
@@ -2666,7 +2666,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 		shared(P, Cells, Hosts, Households)
 	for (int tn = 0; tn < P.NumThreads; tn++)
 	{
-		for (int i = tn; i < P.NC; i+=P.NumThreads)
+		for (int i = tn; i < P.cells_count; i+=P.NumThreads)
 		{
 			if ((Cells[i].tot_treat != 0) || (Cells[i].tot_vacc != 0) || (Cells[i].S != Cells[i].n) || (Cells[i].D > 0) || (Cells[i].R > 0))
 			{
@@ -4334,7 +4334,7 @@ void LoadSnapshot(void)
 
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.population_size) ERR_CRITICAL_FMT("Incorrect N (%i %i) in snapshot file.\n", P.population_size, i);
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.households_count) ERR_CRITICAL("Incorrect NH in snapshot file.\n");
-	fread_big((void*)&i, sizeof(int), 1, dat); if (i != P.NC) ERR_CRITICAL_FMT("## %i neq %i\nIncorrect NC in snapshot file.", i, P.NC);
+	fread_big((void*)&i, sizeof(int), 1, dat); if (i != P.cells_count) ERR_CRITICAL_FMT("## %i neq %i\nIncorrect NC in snapshot file.", i, P.cells_count);
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.NCP) ERR_CRITICAL("Incorrect NCP in snapshot file.\n");
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.ncw) ERR_CRITICAL("Incorrect ncw in snapshot file.\n");
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.nch) ERR_CRITICAL("Incorrect nch in snapshot file.\n");
@@ -4355,7 +4355,7 @@ void LoadSnapshot(void)
 	fprintf(stderr, ".");
 	fread_big((void*)Households, sizeof(Household), (size_t)P.households_count, dat);
 	fprintf(stderr, ".");
-	fread_big((void*)Cells, sizeof(Cell), (size_t)P.NC, dat);
+	fread_big((void*)Cells, sizeof(Cell), (size_t)P.cells_count, dat);
 	fprintf(stderr, ".");
 	fread_big((void*)Mcells, sizeof(Microcell), (size_t)P.NMC, dat);
 	fprintf(stderr, ".");
@@ -4363,7 +4363,7 @@ void LoadSnapshot(void)
 	fprintf(stderr, ".");
 	fread_big((void*)State.CellSuscMemberArray, sizeof(int), (size_t)P.population_size, dat);
 	fprintf(stderr, ".");
-	for (i = 0; i < P.NC; i++)
+	for (i = 0; i < P.cells_count; i++)
 	{
 		if (Cells[i].n > 0)
 		{
@@ -4404,7 +4404,7 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.households_count), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.NC), sizeof(int), 1, dat);
+	fwrite_big((void*) & (P.cells_count), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.NCP), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
@@ -4430,7 +4430,7 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*)Households, sizeof(Household), (size_t)P.households_count, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*)Cells, sizeof(Cell), (size_t)P.NC, dat);
+	fwrite_big((void*)Cells, sizeof(Cell), (size_t)P.cells_count, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*)Mcells, sizeof(Microcell), (size_t)P.NMC, dat);
 	fprintf(stderr, "## %i\n", i++);
@@ -5311,7 +5311,7 @@ void RecordInfTypes(void)
 	for (i = 0; i <= MAX_HOUSEHOLD_SIZE; i++)
 		for (j = 0; j <= MAX_HOUSEHOLD_SIZE; j++)
 			inf_household[i][j] = case_household[i][j] = 0;
-	for (b = 0; b < P.NC; b++)
+	for (b = 0; b < P.cells_count; b++)
 		if ((Cells[b].S != Cells[b].n) || (Cells[b].R > 0))
 			for (c = 0; c < Cells[b].n; c++)
 				Hosts[Cells[b].members[c]].listpos = 0;
@@ -5367,7 +5367,7 @@ void RecordInfTypes(void)
 			}
 		}
 	}
-	for (b = 0; b < P.NC; b++)
+	for (b = 0; b < P.cells_count; b++)
 		if ((Cells[b].S != Cells[b].n) || (Cells[b].R > 0))
 			for (c = 0; c < Cells[b].n; c++)
 			{

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -520,7 +520,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Maximum number of cases defining small outbreak", "%i", (void*) & (P.SmallEpidemicCases), 1, 1, 0)) P.SmallEpidemicCases = -1;
 
 	P.cells_count = -1;
-	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of micro-cells per spatial cell width", "%i", (void*) & (P.NMCL), 1, 1, 0);
+	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of micro-cells per spatial cell width", "%i", (void*) & (P.cell_length_microcells), 1, 1, 0);
 	//added parameter to reset seeds after every run
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Reset seeds for every run", "%i", (void*) & (P.ResetSeeds), 1, 1, 0)) P.ResetSeeds = 0;
 	if (P.ResetSeeds)
@@ -5480,12 +5480,12 @@ void CalcOriginDestMatrix_adunit()
 
 			//find index of cell from which flow travels
 			ptrdiff_t cl_from = CellLookup[i] - Cells;
-			ptrdiff_t cl_from_mcl = (cl_from / P.nch) * P.NMCL * P.get_number_of_micro_cells_high() + (cl_from % P.nch) * P.NMCL;
+			ptrdiff_t cl_from_mcl = (cl_from / P.nch) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_from % P.nch) * P.cell_length_microcells;
 
 			//loop over microcells in these cells to find populations in each admin unit and so flows
-			for (int k = 0; k < P.NMCL; k++)
+			for (int k = 0; k < P.cell_length_microcells; k++)
 			{
-				for (int l = 0; l < P.NMCL; l++)
+				for (int l = 0; l < P.cell_length_microcells; l++)
 				{
 					//get index of microcell
 					ptrdiff_t mcl_from = cl_from_mcl + l + k * P.get_number_of_micro_cells_high();
@@ -5504,7 +5504,7 @@ void CalcOriginDestMatrix_adunit()
 
 				//find index of cell which flow travels to
 				ptrdiff_t cl_to = CellLookup[j] - Cells;
-				ptrdiff_t cl_to_mcl = (cl_to / P.nch) * P.NMCL * P.get_number_of_micro_cells_high() + (cl_to % P.nch) * P.NMCL;
+				ptrdiff_t cl_to_mcl = (cl_to / P.nch) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_to % P.nch) * P.cell_length_microcells;
 				//calculate distance and kernel between the cells
 				//total_flow=Cells[cl_from].max_trans[j]*Cells[cl_from].n*Cells[cl_to].n;
 				double total_flow;
@@ -5518,9 +5518,9 @@ void CalcOriginDestMatrix_adunit()
 				}
 
 				//loop over microcells within destination cell
-				for (int m = 0; m < P.NMCL; m++)
+				for (int m = 0; m < P.cell_length_microcells; m++)
 				{
-					for (int p = 0; p < P.NMCL; p++)
+					for (int p = 0; p < P.cell_length_microcells; p++)
 					{
 						//get index of microcell
 						ptrdiff_t mcl_to = cl_to_mcl + p + m * P.get_number_of_micro_cells_high();

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -441,7 +441,7 @@ int main(int argc, char* argv[])
 		}
 		if (P.OutputNonSummaryResults)
 		{
-			if (((!TimeSeries[P.NumSamples - 1].extinct) || (!P.OutputOnlyNonExtinct)) && (P.OutputEveryRealisation))
+			if (((!TimeSeries[P.samples_count - 1].extinct) || (!P.OutputOnlyNonExtinct)) && (P.OutputEveryRealisation))
 			{
 				SaveResults();
 			}
@@ -508,7 +508,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	P.TimeStepsPerDay = ceil(1.0 / P.TimeStep - 1e-6);
 	fprintf(stderr, "Update step = %lf\nSampling step = %lf\nUpdates per sample=%i\nTimeStepsPerDay=%lf\n", P.TimeStep, P.SampleStep, P.time_steps_between_samples, P.TimeStepsPerDay);
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Sampling time", "%lf", (void*)&(P.SampleTime), 1, 1, 0);
-	P.NumSamples = 1 + (int)ceil(P.SampleTime / P.SampleStep);
+	P.samples_count = 1 + (int)ceil(P.SampleTime / P.SampleStep);
 	GetInputParameter(PreParamFile_dat, AdminFile_dat, "Population size", "%i", (void*)&(P.population_size), 1, 1, 0);
 	if (P.realisations_count == 0)
 		{
@@ -3028,7 +3028,7 @@ int RunModel(int run) //added run number as parameter
 	fs2 = 0;
 	nu = 0;
 
-	for (ns = 1; ((ns < P.NumSamples) && (!InterruptRun)); ns++) //&&(continueEvents) <-removed this
+	for (ns = 1; ((ns < P.samples_count) && (!InterruptRun)); ns++) //&&(continueEvents) <-removed this
 	{
 		RecordSample(t, ns - 1);
 		fprintf(stderr, "\r    t=%lg   %i    %i|%i    %i     %i [=%i]  %i (%lg %lg %lg)   %lg    ", t,
@@ -3113,7 +3113,7 @@ int RunModel(int run) //added run number as parameter
 			}
 		}
 	}
-	if (!InterruptRun) RecordSample(t, P.NumSamples - 1);
+	if (!InterruptRun) RecordSample(t, P.samples_count - 1);
 	fprintf(stderr, "\nEnd of run\n");
 	t2 = t + P.SampleTime;
 //	if(!InterruptRun)
@@ -3290,7 +3290,7 @@ void SaveResults(void)
 		sprintf(outname, "%s.xls", OutFile);
 		if(!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open output file\n");
 		fprintf(dat, "t\tS\tL\tI\tR\tD\tincI\tincR\tincFC\tincC\tincDC\tincTC\tincCT\tincCC\tcumT\tcumTP\tcumV\tcumVG\tExtinct\trmsRad\tmaxRad\n");//\t\t%.10f\t%.10f\t%.10f\n",P.R0household,P.R0places,P.R0spatial);
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10ft%.10f\t%.10f\t%.10f\t%.10f\t%.10f\n",
 				TimeSeries[i].t, TimeSeries[i].S, TimeSeries[i].L, TimeSeries[i].I,
@@ -3311,7 +3311,7 @@ void SaveResults(void)
 		for (i = 0; i < P.NumAdunits; i++) fprintf(dat, "\tDC_%s", AdUnits[i].ad_name);
 
 		fprintf(dat, "\n");
-		for (i = 0; i < P.NumSamples; i++)
+		for (i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10f", TimeSeries[i].t);
 			for (j = 0; j < P.NumAdunits; j++)
@@ -3340,7 +3340,7 @@ void SaveResults(void)
 		}
 		fprintf(dat, "\n");
 		//print actual output
-		for(i=0; i<P.NumSamples; i++)
+		for(i=0; i<P.samples_count; i++)
 		{
 			fprintf(dat, "%.10lf", TimeSeries[i].t);
 			for (j = 0; j < P.NumAdunits; j++)
@@ -3379,7 +3379,7 @@ void SaveResults(void)
 		for(i = 0; i < 2; i++) fprintf(dat, "\tC%i", i);
 		for(i = 0; i < 2; i++) fprintf(dat, "\tT%i", i);
 		fprintf(dat, "\t%i\t%i\n", P.KeyWorkerNum, P.KeyWorkerIncHouseNum);
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 			{
 			fprintf(dat, "%.10f", TimeSeries[i].t);
 			for(j = 0; j < 2; j++)
@@ -3407,7 +3407,7 @@ void SaveResults(void)
 	int d, m, y, dml, f;
 #ifdef _WIN32
 	//if(P.OutputBitmap == 1) CloseAvi(avi);
-	//if((TimeSeries[P.NumSamples - 1].extinct) && (P.OutputOnlyNonExtinct))
+	//if((TimeSeries[P.samples_count - 1].extinct) && (P.OutputOnlyNonExtinct))
 	//	{
 	//	sprintf(outname, "%s.ge" DIRECTORY_SEPARATOR "%s.avi", OutFile, OutFile);
 	//	DeleteFile(outname);
@@ -3426,7 +3426,7 @@ void SaveResults(void)
 		y = 2009;
 		m = 1;
 		d = 1;
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 			{
 			fprintf(dat, "<GroundOverlay>\n<name>Snapshot %i</name>\n", i + 1);
 			fprintf(dat, "<TimeSpan>\n<begin>%i-%02i-%02iT00:00:00Z</begin>\n", y, m, d);
@@ -3466,7 +3466,7 @@ void SaveResults(void)
 		sprintf(outname, "%s.severity.xls", OutFile);
 		if(!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open severity output file\n");
 		fprintf(dat, "t\tRt\tTG\tSI\tS\tI\tR\tincI\tMild\tILI\tSARI\tCritical\tCritRecov\tincMild\tincILI\tincSARI\tincCritical\tincCritRecov\tincDeath\tincDeath_ILI\tincDeath_SARI\tincDeath_Critical\tcumMild\tcumILI\tcumSARI\tcumCritical\tcumCritRecov\tcumDeath\tcumDeath_ILI\tcumDeath_SARI\tcumDeath_Critical\n");//\t\t%.10f\t%.10f\t%.10f\n",P.R0household,P.R0places,P.R0spatial);
-		for (i = 0; i < P.NumSamples; i++)
+		for (i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\t%.10f\n",
 				TimeSeries[i].t, TimeSeries[i].Rdenom, TimeSeries[i].meanTG, TimeSeries[i].meanSI, TimeSeries[i].S, TimeSeries[i].I, TimeSeries[i].R, TimeSeries[i].incI,
@@ -3519,7 +3519,7 @@ void SaveResults(void)
 			fprintf(dat, "\n");
 
 			/////// ****** /////// ****** /////// ****** Populate table.
-			for(i = 0; i < P.NumSamples; i++)
+			for(i = 0; i < P.samples_count; i++)
 			{
 				fprintf(dat, "%.10f", TimeSeries[i].t);
 
@@ -3553,7 +3553,7 @@ void SaveResults(void)
 				for (j = 0; j < P.NumAdunits; j++)		fprintf(dat, "\t%.10f", TimeSeries[i].cumDeath_SARI_adunit[j]);
 				for (j = 0; j < P.NumAdunits; j++)		fprintf(dat, "\t%.10f", TimeSeries[i].cumDeath_Critical_adunit[j]);
 
-				if(i != P.NumSamples - 1) fprintf(dat, "\n");
+				if(i != P.samples_count - 1) fprintf(dat, "\n");
 			}
 			fclose(dat);
 		}
@@ -3579,7 +3579,7 @@ void SaveResults(void)
 		fprintf(dat, "\n");
 
 		// Populate
-		for (int Time = 0; Time < P.NumSamples; Time++)
+		for (int Time = 0; Time < P.samples_count; Time++)
 		{
 			fprintf(dat, "%.10f", TSMean[Time].t);
 			for (int AdUnit = 0; AdUnit < P.NumAdunits; AdUnit++)
@@ -3615,7 +3615,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		c = 1 / ((double)P.NRactual);
 
 		//// populate table
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10f\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t%10lf\t",
 				c * TSMean[i].t, c * TSMean[i].S, c * TSMean[i].L, c * TSMean[i].I, c * TSMean[i].R,
@@ -3647,7 +3647,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		fprintf(dat, "t\tvS\tvincC\tvincTC\tvincFC\tvcumT\tvcumUT\tvcumTP\tvcumV");
 		for(j = 0; j < NUM_PLACE_TYPES; j++) fprintf(dat, "\tvprClosed_%i", j);
 		fprintf(dat, "\n");
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 			{
 			fprintf(dat, "%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf",
 				c * TSMean[i].t, c * TSMean[i].S, c * TSMean[i].incC, c * TSMean[i].incTC, c * TSMean[i].incFC,
@@ -3683,7 +3683,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		for(i = 0; i < NUM_AGE_GROUPS; i++)
 			fprintf(dat, "\tD%i-%i", AGE_GROUP_WIDTH * i, AGE_GROUP_WIDTH * (i + 1));
 		fprintf(dat, "\n");
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 			{
 			fprintf(dat, "%.10f", c * TSMean[i].t);
 			for(j = 0; j < NUM_AGE_GROUPS; j++)
@@ -3713,7 +3713,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		for(i = 0; i < P.NumAdunits; i++) fprintf(dat, "\t%.10f", P.PopByAdunit[i][0]);
 		for(i = 0; i < P.NumAdunits; i++) fprintf(dat, "\t%.10f", P.PopByAdunit[i][1]);
 		fprintf(dat, "\n");
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10f", c * TSMean[i].t);
 			for(j = 0; j < P.NumAdunits; j++)
@@ -3738,7 +3738,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 			for (i = 0; i < P.NumAdunits; i++) fprintf(dat, "\tDC_%s", AdUnits[i].ad_name); //added detected cases: ggilani 03/02/15
 			for (i = 0; i < P.NumAdunits; i++) fprintf(dat, "\tT_%s", AdUnits[i].ad_name);
 			fprintf(dat, "\n");
-			for (i = 0; i < P.NumSamples; i++)
+			for (i = 0; i < P.samples_count; i++)
 			{
 				fprintf(dat, "%.10f", c * TSMean[i].t);
 				for (j = 0; j < P.NumAdunits; j++)
@@ -3770,7 +3770,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		}
 		fprintf(dat, "\n");
 		//print actual output
-		for (i = 0; i < P.NumSamples; i++)
+		for (i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%.10lf", c* TSMean[i].t);
 			for (j = 0; j < P.NumAdunits; j++)
@@ -3800,7 +3800,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		for(i = 0; i < 2; i++) fprintf(dat, "\tvC%i", i);
 		for(i = 0; i < 2; i++) fprintf(dat, "\tvT%i", i);
 		fprintf(dat, "\t%i\t%i\n", P.KeyWorkerNum, P.KeyWorkerIncHouseNum);
-		for(i = 0; i < P.NumSamples; i++)
+		for(i = 0; i < P.samples_count; i++)
 			{
 			fprintf(dat, "%.10f", c * TSMean[i].t);
 			for(j = 0; j < 2; j++)
@@ -3829,7 +3829,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		for (j = 0; j < INFECT_TYPE_MASK; j++) fprintf(dat, "\tincItype_%i", j);
 		for (j = 0; j < NUM_AGE_GROUPS; j++) fprintf(dat, "\tRage_%i", j);
 		fprintf(dat, "\n");
-		for (i = 0; i < P.NumSamples; i++)
+		for (i = 0; i < P.samples_count; i++)
 		{
 			fprintf(dat, "%lf\t%lf\t%lf\t%lf", c * TSMean[i].t, c * TSMean[i].Rdenom, c* TSMean[i].meanTG, c* TSMean[i].meanSI);
 			for (j = 0; j < INFECT_TYPE_MASK; j++) fprintf(dat, "\t%lf", c * TSMean[i].Rtype[j]);
@@ -3919,7 +3919,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		sc3 = (P.Mean_TimeToTest > 0) ? exp(-P.Mean_TimeToTestCriticalOffset / P.Mean_TimeToTest) : 0.0;
 		sc4 = (P.Mean_TimeToTest > 0) ? exp(-P.Mean_TimeToTestCritRecovOffset / P.Mean_TimeToTest) : 0.0;
 		incSARI = incCritical = incCritRecov = 0;
-		for (i = 0; i < P.NumSamples; i++)
+		for (i = 0; i < P.samples_count; i++)
 		{
 			if (i > 0)
 			{
@@ -4039,7 +4039,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 			fprintf(dat, "\n");
 
 			/////// ****** /////// ****** /////// ****** Populate table.
-			for (i = 0; i < P.NumSamples; i++)
+			for (i = 0; i < P.samples_count; i++)
 			{
 				for (j = 0; j < NUM_AGE_GROUPS; j++)
 				{
@@ -4161,7 +4161,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 			fprintf(dat, "\n");
 
 			/////// ****** /////// ****** /////// ****** Populate table.
-			for (i = 0; i < P.NumSamples; i++)
+			for (i = 0; i < P.samples_count; i++)
 			{
 				for (j = 0; j < P.NumAdunits; j++)
 				{
@@ -4246,7 +4246,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		fprintf(dat, "\n");
 
 		// Populate
-		for (int Time = 0; Time < P.NumSamples; Time++)
+		for (int Time = 0; Time < P.samples_count; Time++)
 		{
 			fprintf(dat, "%.10f", c * TSMean[Time].t);
 			for (int AdUnit = 0; AdUnit < P.NumAdunits; AdUnit++)
@@ -4342,7 +4342,7 @@ void LoadSnapshot(void)
 	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed2) ERR_CRITICAL("Incorrect setupSeed2 in snapshot file.\n");
 	fread_big((void*)& t, sizeof(double), 1, dat); if (t != P.TimeStep) ERR_CRITICAL("Incorrect TimeStep in snapshot file.\n");
 	fread_big((void*) & (P.SnapshotLoadTime), sizeof(double), 1, dat);
-	P.NumSamples = 1 + (int)ceil((P.SampleTime - P.SnapshotLoadTime) / P.SampleStep);
+	P.samples_count = 1 + (int)ceil((P.SampleTime - P.SnapshotLoadTime) / P.SampleStep);
 	fprintf(stderr, ".");
 	fread_big((void*)& CellMemberArray, sizeof(int*), 1, dat);
 	fprintf(stderr, ".");
@@ -5297,7 +5297,7 @@ void RecordInfTypes(void)
 	int i, j, k, l, lc, lc2, b, c, n, nf, i2;
 	double* res, * res_av, * res_var, t, s;
 
-	for (n = 0; n < P.NumSamples; n++)
+	for (n = 0; n < P.samples_count; n++)
 	{
 		for (i = 0; i < INFECT_TYPE_MASK; i++) TimeSeries[n].Rtype[i] = 0;
 		for (i = 0; i < NUM_AGE_GROUPS; i++) TimeSeries[n].Rage[i] = 0;
@@ -5378,7 +5378,7 @@ void RecordInfTypes(void)
 					if ((l < MAX_GEN_REC) && (Hosts[i].listpos < MAX_SEC_REC)) indivR0[Hosts[i].listpos][l]++;
 				}
 			}
-	/* 	if(!TimeSeries[P.NumSamples-1].extinct) */
+	/* 	if(!TimeSeries[P.samples_count-1].extinct) */
 	{
 		for (i = 0; i < INFECT_TYPE_MASK; i++) inftype_av[i] += inftype[i];
 		for (i = 0; i < MAX_COUNTRIES; i++)
@@ -5397,7 +5397,7 @@ void RecordInfTypes(void)
 			}
 	}
 	k = (P.PreIntervIdCalTime > 0) ? ((int)(P.PreIntervIdCalTime - P.PreControlClusterIdTime)) : 0;
-	for (n = 0; n < P.NumSamples; n++)
+	for (n = 0; n < P.samples_count; n++)
 	{
 		TimeSeries[n].t += k;
 		s = 0;
@@ -5410,8 +5410,8 @@ void RecordInfTypes(void)
 	}
 	nf = sizeof(Results) / sizeof(double);
 	if (!P.DoAdUnits) nf -= MAX_ADUNITS; // TODO: This still processes most of the AdUnit arrays; just not the last one
-	fprintf(stderr, "extinct=%i (%i)\n", (int) TimeSeries[P.NumSamples - 1].extinct, P.NumSamples - 1);
-	if (TimeSeries[P.NumSamples - 1].extinct)
+	fprintf(stderr, "extinct=%i (%i)\n", (int) TimeSeries[P.samples_count - 1].extinct, P.samples_count - 1);
+	if (TimeSeries[P.samples_count - 1].extinct)
 	{
 		TSMean = TSMeanE; TSVar = TSVarE; P.NRactE++;
 	}
@@ -5422,9 +5422,9 @@ void RecordInfTypes(void)
 	lc = -k;
 
 	// This calculates sum and sum of squares of entire TimeSeries array
-	for (n = 0; n < P.NumSamples; n++)
+	for (n = 0; n < P.samples_count; n++)
 	{
-		if ((n + lc >= 0) && (n + lc < P.NumSamples))
+		if ((n + lc >= 0) && (n + lc < P.samples_count))
 		{
 			if (s < TimeSeries[n + lc].incC) { s = TimeSeries[n + lc].incC; t = P.SampleStep * ((double)(n + lc)); }
 			res = (double*)&TimeSeries[n + lc];

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -683,8 +683,8 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	else
 	{
 
-		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Initial immunity acts as partial immunity", "%i", (void*)&(P.DoPartialImmunity), 1, 1, 0)) P.DoPartialImmunity = 1;
-		if ((P.DoHouseholds)&&(!P.DoPartialImmunity))
+		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Initial immunity acts as partial immunity", "%i", (void*)&(P.respect_partial_immunity), 1, 1, 0)) P.respect_partial_immunity = 1;
+		if ((P.DoHouseholds)&&(!P.respect_partial_immunity))
 		{
 			if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Initial immunity applied to all household members", "%i", (void*) & (P.DoWholeHouseholdImmunity), 1, 1, 0)) P.DoWholeHouseholdImmunity = 0;
 		}
@@ -2649,7 +2649,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 			Hosts[k].index_case_dct = 0;
 			Hosts[k].ProbAbsent =(float) ranf_mt(tn);
 			Hosts[k].ProbCare = (float) ranf_mt(tn);
-			Hosts[k].susc = (float)((P.DoPartialImmunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(k)]) : 1.0);
+			Hosts[k].susc = (float)((P.respect_partial_immunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(k)]) : 1.0);
 			if(P.SusceptibilitySD > 0) Hosts[k].susc *= (float) gen_gamma_mt(1 / (P.SusceptibilitySD * P.SusceptibilitySD), 1 / (P.SusceptibilitySD * P.SusceptibilitySD), tn);
 			if (P.DoSeverity)
 			{
@@ -2683,7 +2683,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 				for (int l = 0; l < MAX_INTERVENTION_TYPES; l++) Cells[i].CurInterv[l] = -1;
 
 				// Next loop needs to count down for DoImmune host list reordering to work
-				if(!P.DoPartialImmunity)
+				if(!P.respect_partial_immunity)
 					for (int j = Cells[i].n - 1; j >= 0; j--)
 					{
 						int k = Cells[i].members[j];

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -285,7 +285,7 @@ int main(int argc, char* argv[])
 				{
 					P.save_snapshots = 1;
 					*sep = ' ';
-					sscanf(buf, "%lf %s", &(P.SnapshotSaveTime), SnapshotSaveFile);
+					sscanf(buf, "%lf %s", &(P.snapshot_save_time), SnapshotSaveFile);
 				}
 			}
 			else if (argv[i][1] == 'B' && argv[i][2] == 'M' && argv[i][3] == ':')
@@ -3016,7 +3016,7 @@ int RunModel(int run) //added run number as parameter
 	lcI = 1;
 	if (P.load_snapshots)
 	{
-		P.ts_age = (int)(P.SnapshotLoadTime * P.TimeStepsPerDay);
+		P.ts_age = (int)(P.snapshot_load_time * P.TimeStepsPerDay);
 		t = ((double)P.ts_age) * P.TimeStep;
 	}
 	else
@@ -3100,7 +3100,7 @@ int RunModel(int run) //added run number as parameter
 				}
 				t += P.TimeStep;
 				if (P.DoDeath) P.ts_age++;
-				if ((P.save_snapshots) && (t <= P.SnapshotSaveTime) && (t + P.TimeStep > P.SnapshotSaveTime)) SaveSnapshot();
+				if ((P.save_snapshots) && (t <= P.snapshot_save_time) && (t + P.TimeStep > P.snapshot_save_time)) SaveSnapshot();
 				if (t > P.TreatNewCoursesStartTime) P.TreatMaxCourses += P.TimeStep * P.TreatNewCoursesRate;
 				if ((t > P.VaccNewCoursesStartTime) && (t < P.VaccNewCoursesEndTime)) P.VaccMaxCourses += P.TimeStep * P.VaccNewCoursesRate;
 				cI = ((double)(State.S)) / ((double)P.population_size);
@@ -4341,8 +4341,8 @@ void LoadSnapshot(void)
 	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed1) ERR_CRITICAL("Incorrect setupSeed1 in snapshot file.\n");
 	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed2) ERR_CRITICAL("Incorrect setupSeed2 in snapshot file.\n");
 	fread_big((void*)& t, sizeof(double), 1, dat); if (t != P.TimeStep) ERR_CRITICAL("Incorrect TimeStep in snapshot file.\n");
-	fread_big((void*) & (P.SnapshotLoadTime), sizeof(double), 1, dat);
-	P.samples_count = 1 + (int)ceil((P.SampleTime - P.SnapshotLoadTime) / P.SampleStep);
+	fread_big((void*) & (P.snapshot_load_time), sizeof(double), 1, dat);
+	P.samples_count = 1 + (int)ceil((P.SampleTime - P.snapshot_load_time) / P.SampleStep);
 	fprintf(stderr, ".");
 	fread_big((void*)& CellMemberArray, sizeof(int*), 1, dat);
 	fprintf(stderr, ".");
@@ -4418,7 +4418,7 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.TimeStep), sizeof(double), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.SnapshotSaveTime), sizeof(double), 1, dat);
+	fwrite_big((void*) & (P.snapshot_save_time), sizeof(double), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (State.CellMemberArray), sizeof(int*), 1, dat);
 	fprintf(stderr, "## %i\n", i++);

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -931,13 +931,13 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	}
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Daily seasonality coefficients", "%lf", (void*)P.Seasonality, DAYS_PER_YEAR, 1, 0))
 	{
-		P.DoSeasonality = 0;
+		P.respect_seasonality_variations = 0;
 		for (i = 0; i < DAYS_PER_YEAR; i++)
 			P.Seasonality[i] = 1;
 	}
 	else
 	{
-		P.DoSeasonality = 1;
+		P.respect_seasonality_variations = 1;
 		s = 0;
 		for (i = 0; i < DAYS_PER_YEAR; i++)
 			s += P.Seasonality[i];

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -460,7 +460,7 @@ int main(int argc, char* argv[])
 		SaveOriginDestMatrix();
 	}
 
-	P.NRactual = P.NRactNE;
+	P.actual_realisations_count = P.NRactNE;
 	TSMean = TSMeanNE; TSVar = TSVarNE;
 	if ((P.DoRecordInfEvents) && (P.RecordInfEventsPerRun == 0))
 	{
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
 	}
 	sprintf(OutFile, "%s.avNE", OutFileBase);
 	SaveSummaryResults();
-	P.NRactual = P.NRactE;
+	P.actual_realisations_count = P.NRactE;
 	TSMean = TSMeanE; TSVar = TSVarE;
 	sprintf(OutFile, "%s.avE", OutFileBase);
 	//SaveSummaryResults();
@@ -3612,7 +3612,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		//// set colnames
 		fprintf(dat, "t\tS\tL\tI\tR\tD\tincI\tincR\tincD\tincC\tincDC\tincTC\tcumT\tcumTmax\tcumTP\tcumV\tcumVmax\tExtinct\trmsRad\tmaxRad\tvS\tvI\tvR\tvD\tvincI\tvincR\tvincFC\tvincC\tvincDC\tvincTC\tvrmsRad\tvmaxRad\t\t%i\t%i\t%.10f\t%.10f\t%.10f\t\t%.10f\t%.10f\t%.10f\t%.10f\n",
 			P.NRactNE, P.NRactE, P.R0household, P.R0places, P.R0spatial, c * PeakHeightSum, c * PeakHeightSS - c * c * PeakHeightSum * PeakHeightSum, c * PeakTimeSum, c * PeakTimeSS - c * c * PeakTimeSum * PeakTimeSum);
-		c = 1 / ((double)P.NRactual);
+		c = 1 / ((double)P.actual_realisations_count);
 
 		//// populate table
 		for(i = 0; i < P.samples_count; i++)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2718,7 +2718,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 
 #pragma omp parallel for schedule(static,500) default(none) \
 		shared(P, Mcells, McellLookup)
-	for (int l = 0; l < P.NMCP; l++)
+	for (int l = 0; l < P.populated_microcells_count; l++)
 	{
 		int i = (int)(McellLookup[l] - Mcells);
 		Mcells[i].vacc_start_time = Mcells[i].treat_start_time = USHRT_MAX - 1;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -4333,7 +4333,7 @@ void LoadSnapshot(void)
 	}
 
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.population_size) ERR_CRITICAL_FMT("Incorrect N (%i %i) in snapshot file.\n", P.population_size, i);
-	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.NH) ERR_CRITICAL("Incorrect NH in snapshot file.\n");
+	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.households_count) ERR_CRITICAL("Incorrect NH in snapshot file.\n");
 	fread_big((void*)&i, sizeof(int), 1, dat); if (i != P.NC) ERR_CRITICAL_FMT("## %i neq %i\nIncorrect NC in snapshot file.", i, P.NC);
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.NCP) ERR_CRITICAL("Incorrect NCP in snapshot file.\n");
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.ncw) ERR_CRITICAL("Incorrect ncw in snapshot file.\n");
@@ -4353,7 +4353,7 @@ void LoadSnapshot(void)
 
 	fread_big((void*)Hosts, sizeof(Person), (size_t)P.population_size, dat);
 	fprintf(stderr, ".");
-	fread_big((void*)Households, sizeof(Household), (size_t)P.NH, dat);
+	fread_big((void*)Households, sizeof(Household), (size_t)P.households_count, dat);
 	fprintf(stderr, ".");
 	fread_big((void*)Cells, sizeof(Cell), (size_t)P.NC, dat);
 	fprintf(stderr, ".");
@@ -4402,7 +4402,7 @@ void SaveSnapshot(void)
 
 	fwrite_big((void*) & (P.population_size), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.NH), sizeof(int), 1, dat);
+	fwrite_big((void*) & (P.households_count), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.NC), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
@@ -4428,7 +4428,7 @@ void SaveSnapshot(void)
 	fwrite_big((void*)Hosts, sizeof(Person), (size_t)P.population_size, dat);
 
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*)Households, sizeof(Household), (size_t)P.NH, dat);
+	fwrite_big((void*)Households, sizeof(Household), (size_t)P.households_count, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*)Cells, sizeof(Cell), (size_t)P.NC, dat);
 	fprintf(stderr, "## %i\n", i++);

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 		P.PreControlClusterIdCaseThreshold = 0;
 		P.R0scale = 1.0;
 		P.KernelOffsetScale = P.KernelPowerScale = 1.0; //added this so that kernel parameters are only changed if input from the command line: ggilani - 15/10/2014
-		P.DoSaveSnapshot = P.DoLoadSnapshot  = 0;
+		P.save_snapshots = P.load_snapshots  = 0;
 
 		//// scroll through command line arguments, anticipating what they can be using various if statements.
 		for (i = 1; i < argc - 4; i++)
@@ -267,7 +267,7 @@ int main(int argc, char* argv[])
 			else if (argv[i][1] == 'L' && argv[i][2] == 'S' && argv[i][3] == ':')
 			{
 				sscanf(&argv[i][4], "%s", SnapshotLoadFile);
-				P.DoLoadSnapshot = 1;
+				P.load_snapshots = 1;
 			}
 			else if (argv[i][1] == 'P' && argv[i][2] == 'P' && argv[i][3] == ':')
 			{
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
 					Perr = 1;
 				else
 				{
-					P.DoSaveSnapshot = 1;
+					P.save_snapshots = 1;
 					*sep = ' ';
 					sscanf(buf, "%lf %s", &(P.SnapshotSaveTime), SnapshotSaveFile);
 				}
@@ -416,7 +416,7 @@ int main(int argc, char* argv[])
 
 		///// initialize model (for this realisation).
 		InitModel(i); //passing run number into RunModel so we can save run number in the infection event log: ggilani - 15/10/2014
-		if (P.DoLoadSnapshot) LoadSnapshot();
+		if (P.load_snapshots) LoadSnapshot();
 		int ModelCalibLoop = 0;
 		while (RunModel(i))
 		{  // has been interrupted to reset holiday time. Note that this currently only happens in the first run, regardless of how many realisations are being run.
@@ -3014,7 +3014,7 @@ int RunModel(int run) //added run number as parameter
 */
 	InterruptRun = 0;
 	lcI = 1;
-	if (P.DoLoadSnapshot)
+	if (P.load_snapshots)
 	{
 		P.ts_age = (int)(P.SnapshotLoadTime * P.TimeStepsPerDay);
 		t = ((double)P.ts_age) * P.TimeStep;
@@ -3100,7 +3100,7 @@ int RunModel(int run) //added run number as parameter
 				}
 				t += P.TimeStep;
 				if (P.DoDeath) P.ts_age++;
-				if ((P.DoSaveSnapshot) && (t <= P.SnapshotSaveTime) && (t + P.TimeStep > P.SnapshotSaveTime)) SaveSnapshot();
+				if ((P.save_snapshots) && (t <= P.SnapshotSaveTime) && (t + P.TimeStep > P.SnapshotSaveTime)) SaveSnapshot();
 				if (t > P.TreatNewCoursesStartTime) P.TreatMaxCourses += P.TimeStep * P.TreatNewCoursesRate;
 				if ((t > P.VaccNewCoursesStartTime) && (t < P.VaccNewCoursesEndTime)) P.VaccMaxCourses += P.TimeStep * P.VaccNewCoursesRate;
 				cI = ((double)(State.S)) / ((double)P.population_size);

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -552,10 +552,10 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	{
 		ERR_CRITICAL_FMT("[Kernel resolution] needs to be at least 2000000 - not %d", P.kernel_lookup_table_size);
 	}
-	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel higher resolution factor", "%i", (void*)&P.NK_HR, 1, 1, 0)) P.NK_HR = P.kernel_lookup_table_size / 1600;
-	if (P.NK_HR < 1 || P.NK_HR >= P.kernel_lookup_table_size)
+	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel higher resolution factor", "%i", (void*)&P.high_resolution_kernel_lookup_table_expansion_factor, 1, 1, 0)) P.high_resolution_kernel_lookup_table_expansion_factor = P.kernel_lookup_table_size / 1600;
+	if (P.high_resolution_kernel_lookup_table_expansion_factor < 1 || P.high_resolution_kernel_lookup_table_expansion_factor >= P.kernel_lookup_table_size)
 	{
-		ERR_CRITICAL_FMT("[Kernel higher resolution factor] needs to be in range [1, P.NKR = %d) - not %d", P.kernel_lookup_table_size, P.NK_HR);
+		ERR_CRITICAL_FMT("[Kernel higher resolution factor] needs to be in range [1, P.NKR = %d) - not %d", P.kernel_lookup_table_size, P.high_resolution_kernel_lookup_table_expansion_factor);
 	}
 
 	if (P.DoHouseholds)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -386,7 +386,7 @@ int main(int argc, char* argv[])
 
 
 	P.NRactE = P.NRactNE = 0;
-	for (i = 0; (i < P.realisations_count) && (P.NRactNE < P.NumNonExtinctRealisations) ; i++)
+	for (i = 0; (i < P.realisations_count) && (P.NRactNE < P.non_extinct_realisations_count) ; i++)
 	{
 		if (P.realisations_count > 1)
 		{
@@ -513,10 +513,10 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (P.realisations_count == 0)
 		{
 		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of realisations", "%i", (void*)&(P.realisations_count), 1, 1, 0);
-		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Number of non-extinct realisations", "%i", (void*)&(P.NumNonExtinctRealisations), 1, 1, 0)) P.NumNonExtinctRealisations = P.realisations_count;
+		if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Number of non-extinct realisations", "%i", (void*)&(P.non_extinct_realisations_count), 1, 1, 0)) P.non_extinct_realisations_count = P.realisations_count;
 		}
 	else
-		P.NumNonExtinctRealisations = P.realisations_count;
+		P.non_extinct_realisations_count = P.realisations_count;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Maximum number of cases defining small outbreak", "%i", (void*) & (P.SmallEpidemicCases), 1, 1, 0)) P.SmallEpidemicCases = -1;
 
 	P.NC = -1;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -4357,7 +4357,7 @@ void LoadSnapshot(void)
 	fprintf(stderr, ".");
 	fread_big((void*)Cells, sizeof(Cell), (size_t)P.cells_count, dat);
 	fprintf(stderr, ".");
-	fread_big((void*)Mcells, sizeof(Microcell), (size_t)P.NMC, dat);
+	fread_big((void*)Mcells, sizeof(Microcell), (size_t)P.microcells_count, dat);
 	fprintf(stderr, ".");
 	fread_big((void*)State.CellMemberArray, sizeof(int), (size_t)P.population_size, dat);
 	fprintf(stderr, ".");
@@ -4374,7 +4374,7 @@ void LoadSnapshot(void)
 		}
 		for (j = 0; j < MAX_INTERVENTION_TYPES; j++) Cells[i].CurInterv[j] = -1; // turn interventions off in loaded image
 	}
-	for (i = 0; i < P.NMC; i++)
+	for (i = 0; i < P.microcells_count; i++)
 		if (Mcells[i].n > 0)
 			Mcells[i].members += CM_offset;
 
@@ -4432,7 +4432,7 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*)Cells, sizeof(Cell), (size_t)P.cells_count, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*)Mcells, sizeof(Microcell), (size_t)P.NMC, dat);
+	fwrite_big((void*)Mcells, sizeof(Microcell), (size_t)P.microcells_count, dat);
 	fprintf(stderr, "## %i\n", i++);
 
 	fwrite_big((void*)State.CellMemberArray, sizeof(int), (size_t)P.population_size, dat);
@@ -5096,8 +5096,8 @@ void RecordSample(double t, int n)
 			State.NumPlacesClosed[i] = numPC;
 			TimeSeries[n].PropPlacesClosed[i] = ((double)numPC) / ((double)P.Nplace[i]);
 		}
-	for (int i = k = 0; i < P.NMC; i++) if (Mcells[i].socdist == 2) k++;
-	TimeSeries[n].PropSocDist=((double)k)/((double)P.NMC);
+	for (int i = k = 0; i < P.microcells_count; i++) if (Mcells[i].socdist == 2) k++;
+	TimeSeries[n].PropSocDist=((double)k)/((double)P.microcells_count);
 
 	//update contact number distribution in State
 	for (int i = 0; i < (MAX_CONTACTS+1); i++)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -4336,8 +4336,8 @@ void LoadSnapshot(void)
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.households_count) ERR_CRITICAL("Incorrect NH in snapshot file.\n");
 	fread_big((void*)&i, sizeof(int), 1, dat); if (i != P.cells_count) ERR_CRITICAL_FMT("## %i neq %i\nIncorrect NC in snapshot file.", i, P.cells_count);
 	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.populated_cells_count) ERR_CRITICAL("Incorrect NCP in snapshot file.\n");
-	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.ncw) ERR_CRITICAL("Incorrect ncw in snapshot file.\n");
-	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.nch) ERR_CRITICAL("Incorrect nch in snapshot file.\n");
+	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.cell_grid_width) ERR_CRITICAL("Incorrect cell_grid_width in snapshot file.\n");
+	fread_big((void*)& i, sizeof(int), 1, dat); if (i != P.cell_grid_height) ERR_CRITICAL("Incorrect nch in snapshot file.\n");
 	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed1) ERR_CRITICAL("Incorrect setupSeed1 in snapshot file.\n");
 	fread_big((void*)& l, sizeof(int32_t), 1, dat); if (l != P.setupSeed2) ERR_CRITICAL("Incorrect setupSeed2 in snapshot file.\n");
 	fread_big((void*)& t, sizeof(double), 1, dat); if (t != P.TimeStep) ERR_CRITICAL("Incorrect TimeStep in snapshot file.\n");
@@ -4408,9 +4408,9 @@ void SaveSnapshot(void)
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.populated_cells_count), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.ncw), sizeof(int), 1, dat);
+	fwrite_big((void*) & (P.cell_grid_width), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
-	fwrite_big((void*) & (P.nch), sizeof(int), 1, dat);
+	fwrite_big((void*) & (P.cell_grid_height), sizeof(int), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
 	fwrite_big((void*) & (P.setupSeed1), sizeof(int32_t), 1, dat);
 	fprintf(stderr, "## %i\n", i++);
@@ -5480,7 +5480,7 @@ void CalcOriginDestMatrix_adunit()
 
 			//find index of cell from which flow travels
 			ptrdiff_t cl_from = CellLookup[i] - Cells;
-			ptrdiff_t cl_from_mcl = (cl_from / P.nch) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_from % P.nch) * P.cell_length_microcells;
+			ptrdiff_t cl_from_mcl = (cl_from / P.cell_grid_height) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_from % P.cell_grid_height) * P.cell_length_microcells;
 
 			//loop over microcells in these cells to find populations in each admin unit and so flows
 			for (int k = 0; k < P.cell_length_microcells; k++)
@@ -5504,7 +5504,7 @@ void CalcOriginDestMatrix_adunit()
 
 				//find index of cell which flow travels to
 				ptrdiff_t cl_to = CellLookup[j] - Cells;
-				ptrdiff_t cl_to_mcl = (cl_to / P.nch) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_to % P.nch) * P.cell_length_microcells;
+				ptrdiff_t cl_to_mcl = (cl_to / P.cell_grid_height) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (cl_to % P.cell_grid_height) * P.cell_length_microcells;
 				//calculate distance and kernel between the cells
 				//total_flow=Cells[cl_from].max_trans[j]*Cells[cl_from].n*Cells[cl_to].n;
 				double total_flow;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -563,7 +563,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 		GetInputParameter(PreParamFile_dat, AdminFile_dat, "Household size distribution", "%lf", (void*)P.HouseholdSizeDistrib[0], MAX_HOUSEHOLD_SIZE, 1, 0);
 		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Household attack rate", "%lf", (void*) & (P.HouseholdTrans), 1, 1, 0);
 		GetInputParameter(ParamFile_dat, PreParamFile_dat, "Household transmission denominator power", "%lf", (void*) & (P.HouseholdTransPow), 1, 1, 0);
-		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Correct age distribution after household allocation to exactly match specified demography", "%i", (void*)&(P.DoCorrectAgeDist), 1, 1, 0)) P.DoCorrectAgeDist = 0;
+		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Correct age distribution after household allocation to exactly match specified demography", "%i", (void*)&(P.should_correct_age_distributions), 1, 1, 0)) P.should_correct_age_distributions = 0;
 	}
 	else
 	{

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -547,15 +547,15 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "OutputNonSeverity"		, "%i", (void*) & (P.OutputNonSeverity)			, 1, 1, 0)) P.OutputNonSeverity = 0;		//// OFF by default.
   	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "OutputNonSummaryResults"	, "%i", (void*) & (P.OutputNonSummaryResults)	, 1, 1, 0)) P.OutputNonSummaryResults = 0;	//// OFF by default.
 
-	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel resolution", "%i", (void*)&P.NKR, 1, 1, 0)) P.NKR = 4000000;
-	if (P.NKR < 2000000)
+	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel resolution", "%i", (void*)&P.kernel_lookup_table_size, 1, 1, 0)) P.kernel_lookup_table_size = 4000000;
+	if (P.kernel_lookup_table_size < 2000000)
 	{
-		ERR_CRITICAL_FMT("[Kernel resolution] needs to be at least 2000000 - not %d", P.NKR);
+		ERR_CRITICAL_FMT("[Kernel resolution] needs to be at least 2000000 - not %d", P.kernel_lookup_table_size);
 	}
-	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel higher resolution factor", "%i", (void*)&P.NK_HR, 1, 1, 0)) P.NK_HR = P.NKR / 1600;
-	if (P.NK_HR < 1 || P.NK_HR >= P.NKR)
+	if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Kernel higher resolution factor", "%i", (void*)&P.NK_HR, 1, 1, 0)) P.NK_HR = P.kernel_lookup_table_size / 1600;
+	if (P.NK_HR < 1 || P.NK_HR >= P.kernel_lookup_table_size)
 	{
-		ERR_CRITICAL_FMT("[Kernel higher resolution factor] needs to be in range [1, P.NKR = %d) - not %d", P.NKR, P.NK_HR);
+		ERR_CRITICAL_FMT("[Kernel higher resolution factor] needs to be in range [1, P.NKR = %d) - not %d", P.kernel_lookup_table_size, P.NK_HR);
 	}
 
 	if (P.DoHouseholds)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -385,7 +385,7 @@ int main(int argc, char* argv[])
 	//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 
 
-	P.NRactE = P.NRactNE = 0;
+	P.actual_extinct_realisations_count = P.NRactNE = 0;
 	for (i = 0; (i < P.realisations_count) && (P.NRactNE < P.non_extinct_realisations_count) ; i++)
 	{
 		if (P.realisations_count > 1)
@@ -468,14 +468,14 @@ int main(int argc, char* argv[])
 	}
 	sprintf(OutFile, "%s.avNE", OutFileBase);
 	SaveSummaryResults();
-	P.actual_realisations_count = P.NRactE;
+	P.actual_realisations_count = P.actual_extinct_realisations_count;
 	TSMean = TSMeanE; TSVar = TSVarE;
 	sprintf(OutFile, "%s.avE", OutFileBase);
 	//SaveSummaryResults();
 
 	Bitmap_Finalise();
 
-	fprintf(stderr, "Extinction in %i out of %i runs\n", P.NRactE, P.NRactNE + P.NRactE);
+	fprintf(stderr, "Extinction in %i out of %i runs\n", P.actual_extinct_realisations_count, P.NRactNE + P.actual_extinct_realisations_count);
 	fprintf(stderr, "Model ran in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
 	fprintf(stderr, "Model finished\n");
 }
@@ -3603,7 +3603,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 	FILE* dat;
 	char outname[1024];
 
-	c = 1 / ((double)(P.NRactE + P.NRactNE));
+	c = 1 / ((double)(P.actual_extinct_realisations_count + P.NRactNE));
 
 	if (P.OutputNonSeverity)
 	{
@@ -3611,7 +3611,7 @@ void SaveSummaryResults(void) //// calculates and saves summary results (called 
 		if(!(dat = fopen(outname, "wb"))) ERR_CRITICAL("Unable to open output file\n");
 		//// set colnames
 		fprintf(dat, "t\tS\tL\tI\tR\tD\tincI\tincR\tincD\tincC\tincDC\tincTC\tcumT\tcumTmax\tcumTP\tcumV\tcumVmax\tExtinct\trmsRad\tmaxRad\tvS\tvI\tvR\tvD\tvincI\tvincR\tvincFC\tvincC\tvincDC\tvincTC\tvrmsRad\tvmaxRad\t\t%i\t%i\t%.10f\t%.10f\t%.10f\t\t%.10f\t%.10f\t%.10f\t%.10f\n",
-			P.NRactNE, P.NRactE, P.R0household, P.R0places, P.R0spatial, c * PeakHeightSum, c * PeakHeightSS - c * c * PeakHeightSum * PeakHeightSum, c * PeakTimeSum, c * PeakTimeSS - c * c * PeakTimeSum * PeakTimeSum);
+				P.NRactNE, P.actual_extinct_realisations_count, P.R0household, P.R0places, P.R0spatial, c * PeakHeightSum, c * PeakHeightSS - c * c * PeakHeightSum * PeakHeightSum, c * PeakTimeSum, c * PeakTimeSS - c * c * PeakTimeSum * PeakTimeSum);
 		c = 1 / ((double)P.actual_realisations_count);
 
 		//// populate table
@@ -5413,7 +5413,7 @@ void RecordInfTypes(void)
 	fprintf(stderr, "extinct=%i (%i)\n", (int) TimeSeries[P.samples_count - 1].extinct, P.samples_count - 1);
 	if (TimeSeries[P.samples_count - 1].extinct)
 	{
-		TSMean = TSMeanE; TSVar = TSVarE; P.NRactE++;
+		TSMean = TSMeanE; TSVar = TSVarE; P.actual_extinct_realisations_count++;
 	}
 	else
 	{

--- a/src/Dist.cpp
+++ b/src/Dist.cpp
@@ -41,7 +41,7 @@ double dist2(Person* a, Person* b)
 {
 	double x, y;
 
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 		return dist2UTM(Households[a->hh].loc_x, Households[a->hh].loc_y, Households[b->hh].loc_x, Households[b->hh].loc_y);
 	else
 	{
@@ -62,7 +62,7 @@ double dist2_cc(Cell* a, Cell* b)
 
 	l = (int)(a - Cells);
 	m = (int)(b - Cells);
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 		return dist2UTM(P.in_cells_.width_ * fabs((double)(l / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(l % P.cell_grid_height)),
 			P.in_cells_.width_ * fabs((double)(m / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(m % P.cell_grid_height)));
 	else
@@ -85,7 +85,7 @@ double dist2_cc_min(Cell* a, Cell* b)
 	l = (int)(a - Cells);
 	m = (int)(b - Cells);
 	i = l; j = m;
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 	{
 		if (P.in_cells_.width_ * ((double)abs(m / P.cell_grid_height - l / P.cell_grid_height)) > PI)
 		{
@@ -155,7 +155,7 @@ double dist2_mm(Microcell* a, Microcell* b)
 
 	l = (int)(a - Mcells);
 	m = (int)(b - Mcells);
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 		return dist2UTM(P.in_microcells_.width_ * fabs((double)(l / P.get_number_of_micro_cells_high())), P.in_microcells_.height_ * fabs((double)(l % P.get_number_of_micro_cells_high())),
 			P.in_microcells_.width_ * fabs((double)(m / P.get_number_of_micro_cells_high())), P.in_microcells_.height_ * fabs((double)(m % P.get_number_of_micro_cells_high())));
 	else
@@ -175,7 +175,7 @@ double dist2_raw(double ax, double ay, double bx, double by)
 {
 	double x, y;
 
-	if (P.DoUTM_coords)
+	if (P.use_utm_coordinate_system)
 		return dist2UTM(ax, ay, bx, by);
 	else
 	{

--- a/src/Dist.cpp
+++ b/src/Dist.cpp
@@ -63,12 +63,12 @@ double dist2_cc(Cell* a, Cell* b)
 	l = (int)(a - Cells);
 	m = (int)(b - Cells);
 	if (P.DoUTM_coords)
-		return dist2UTM(P.in_cells_.width_ * fabs((double)(l / P.nch)), P.in_cells_.height_ * fabs((double)(l % P.nch)),
-			P.in_cells_.width_ * fabs((double)(m / P.nch)), P.in_cells_.height_ * fabs((double)(m % P.nch)));
+		return dist2UTM(P.in_cells_.width_ * fabs((double)(l / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(l % P.cell_grid_height)),
+			P.in_cells_.width_ * fabs((double)(m / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(m % P.cell_grid_height)));
 	else
 	{
-		x = P.in_cells_.width_ * fabs((double)(l / P.nch - m / P.nch));
-		y = P.in_cells_.height_ * fabs((double)(l % P.nch - m % P.nch));
+		x = P.in_cells_.width_ * fabs((double)(l / P.cell_grid_height - m / P.cell_grid_height));
+		y = P.in_cells_.height_ * fabs((double)(l % P.cell_grid_height - m % P.cell_grid_height));
 		if (P.DoPeriodicBoundaries)
 		{
 			if (x > P.in_degrees_.width_ * 0.5) x = P.in_degrees_.width_ - x;
@@ -87,59 +87,59 @@ double dist2_cc_min(Cell* a, Cell* b)
 	i = l; j = m;
 	if (P.DoUTM_coords)
 	{
-		if (P.in_cells_.width_ * ((double)abs(m / P.nch - l / P.nch)) > PI)
+		if (P.in_cells_.width_ * ((double)abs(m / P.cell_grid_height - l / P.cell_grid_height)) > PI)
 		{
-			if (m / P.nch > l / P.nch)
-				j += P.nch;
-			else if (m / P.nch < l / P.nch)
-				i += P.nch;
+			if (m / P.cell_grid_height > l / P.cell_grid_height)
+				j += P.cell_grid_height;
+			else if (m / P.cell_grid_height < l / P.cell_grid_height)
+				i += P.cell_grid_height;
 		}
 		else
 		{
-			if (m / P.nch > l / P.nch)
-				i += P.nch;
-			else if (m / P.nch < l / P.nch)
-				j += P.nch;
+			if (m / P.cell_grid_height > l / P.cell_grid_height)
+				i += P.cell_grid_height;
+			else if (m / P.cell_grid_height < l / P.cell_grid_height)
+				j += P.cell_grid_height;
 		}
-		if (m % P.nch > l % P.nch)
+		if (m % P.cell_grid_height > l % P.cell_grid_height)
 			i++;
-		else if (m % P.nch < l % P.nch)
+		else if (m % P.cell_grid_height < l % P.cell_grid_height)
 			j++;
-		return dist2UTM(P.in_cells_.width_ * fabs((double)(i / P.nch)), P.in_cells_.height_ * fabs((double)(i % P.nch)),
-			P.in_cells_.width_ * fabs((double)(j / P.nch)), P.in_cells_.height_ * fabs((double)(j % P.nch)));
+		return dist2UTM(P.in_cells_.width_ * fabs((double)(i / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(i % P.cell_grid_height)),
+			P.in_cells_.width_ * fabs((double)(j / P.cell_grid_height)), P.in_cells_.height_ * fabs((double)(j % P.cell_grid_height)));
 	}
 	else
 	{
-		if ((P.DoPeriodicBoundaries) && (P.in_cells_.width_ * ((double)abs(m / P.nch - l / P.nch)) > P.in_degrees_.width_ * 0.5))
+		if ((P.DoPeriodicBoundaries) && (P.in_cells_.width_ * ((double)abs(m / P.cell_grid_height - l / P.cell_grid_height)) > P.in_degrees_.width_ * 0.5))
 		{
-			if (m / P.nch > l / P.nch)
-				j += P.nch;
-			else if (m / P.nch < l / P.nch)
-				i += P.nch;
+			if (m / P.cell_grid_height > l / P.cell_grid_height)
+				j += P.cell_grid_height;
+			else if (m / P.cell_grid_height < l / P.cell_grid_height)
+				i += P.cell_grid_height;
 		}
 		else
 		{
-			if (m / P.nch > l / P.nch)
-				i += P.nch;
-			else if (m / P.nch < l / P.nch)
-				j += P.nch;
+			if (m / P.cell_grid_height > l / P.cell_grid_height)
+				i += P.cell_grid_height;
+			else if (m / P.cell_grid_height < l / P.cell_grid_height)
+				j += P.cell_grid_height;
 		}
-		if ((P.DoPeriodicBoundaries) && (P.in_degrees_.height_ * ((double)abs(m % P.nch - l % P.nch)) > P.in_degrees_.height_ * 0.5))
+		if ((P.DoPeriodicBoundaries) && (P.in_degrees_.height_ * ((double)abs(m % P.cell_grid_height - l % P.cell_grid_height)) > P.in_degrees_.height_ * 0.5))
 		{
-			if (m % P.nch > l % P.nch)
+			if (m % P.cell_grid_height > l % P.cell_grid_height)
 				j++;
-			else if (m % P.nch < l % P.nch)
+			else if (m % P.cell_grid_height < l % P.cell_grid_height)
 				i++;
 		}
 		else
 		{
-			if (m % P.nch > l % P.nch)
+			if (m % P.cell_grid_height > l % P.cell_grid_height)
 				i++;
-			else if (m % P.nch < l % P.nch)
+			else if (m % P.cell_grid_height < l % P.cell_grid_height)
 				j++;
 		}
-		x = P.in_cells_.width_ * fabs((double)(i / P.nch - j / P.nch));
-		y = P.in_cells_.height_ * fabs((double)(i % P.nch - j % P.nch));
+		x = P.in_cells_.width_ * fabs((double)(i / P.cell_grid_height - j / P.cell_grid_height));
+		y = P.in_cells_.height_ * fabs((double)(i % P.cell_grid_height - j % P.cell_grid_height));
 		if (P.DoPeriodicBoundaries)
 		{
 			if (x > P.in_degrees_.width_ * 0.5) x = P.in_degrees_.width_ - x;

--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -49,7 +49,7 @@ void InitKernel(double norm)
 	for (int i = 0; i <= P.kernel_lookup_table_size; i++)
 	{
 		nKernel[i] = (*Kernel)(((double)i) * P.KernelDelta) / norm;
-		nKernelHR[i] = (*Kernel)(((double)i) * P.KernelDelta / P.NK_HR) / norm;
+		nKernelHR[i] = (*Kernel)(((double)i) * P.KernelDelta / P.high_resolution_kernel_lookup_table_expansion_factor) / norm;
 	}
 
 #pragma omp parallel for schedule(static,500) default(none) \
@@ -119,7 +119,7 @@ double numKernel(double r2)
 		ERR_CRITICAL("r too large in NumKernel\n");
 	}
 
-	double s = t * P.NK_HR;
+	double s = t * P.high_resolution_kernel_lookup_table_expansion_factor;
 	if (s < P.kernel_lookup_table_size)
 	{
 		t = s - floor(s);

--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -54,11 +54,11 @@ void InitKernel(double norm)
 
 #pragma omp parallel for schedule(static,500) default(none) \
 		shared(P, CellLookup)
-	for (int i = 0; i < P.NCP; i++)
+	for (int i = 0; i < P.populated_cells_count; i++)
 	{
 		Cell *l = CellLookup[i];
 		l->tot_prob = 0;
-		for (int j = 0; j < P.NCP; j++)
+		for (int j = 0; j < P.populated_cells_count; j++)
 		{
 			Cell *m = CellLookup[j];
 			l->max_trans[j] = (float)numKernel(dist2_cc_min(l, m));

--- a/src/Kernels.cpp
+++ b/src/Kernels.cpp
@@ -46,7 +46,7 @@ void InitKernel(double norm)
 
 #pragma omp parallel for schedule(static,500) default(none) \
 		shared(P, Kernel, nKernel, nKernelHR, norm)
-	for (int i = 0; i <= P.NKR; i++)
+	for (int i = 0; i <= P.kernel_lookup_table_size; i++)
 	{
 		nKernel[i] = (*Kernel)(((double)i) * P.KernelDelta) / norm;
 		nKernelHR[i] = (*Kernel)(((double)i) * P.KernelDelta / P.NK_HR) / norm;
@@ -113,14 +113,14 @@ double PowerExpKernel(double r2)
 double numKernel(double r2)
 {
 	double t = r2 / P.KernelDelta;
-	if (t > P.NKR)
+	if (t > P.kernel_lookup_table_size)
 	{
 		fprintf(stderr, "** %lg  %lg  %lg**\n", r2, P.KernelDelta, t);
 		ERR_CRITICAL("r too large in NumKernel\n");
 	}
 
 	double s = t * P.NK_HR;
-	if (s < P.NKR)
+	if (s < P.kernel_lookup_table_size)
 	{
 		t = s - floor(s);
 		t = (1 - t) * nKernelHR[(int)s] + t * nKernelHR[(int)(s + 1)];

--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -1,11 +1,11 @@
 #include "Param.h"
 
 int Param::get_number_of_micro_cells_wide() const {
-	return this->ncw * this->cell_length_microcells;
+	return this->cell_grid_width * this->cell_length_microcells;
 }
 
 int Param::get_number_of_micro_cells_high() const {
-	return this->nch * this->cell_length_microcells;
+	return this->cell_grid_height * this->cell_length_microcells;
 }
 
 MicroCellPosition Param::get_micro_cell_position_from_cell_index(int cell_index) const {

--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -1,11 +1,11 @@
 #include "Param.h"
 
 int Param::get_number_of_micro_cells_wide() const {
-	return this->ncw * this->NMCL;
+	return this->ncw * this->cell_length_microcells;
 }
 
 int Param::get_number_of_micro_cells_high() const {
-	return this->nch * this->NMCL;
+	return this->nch * this->cell_length_microcells;
 }
 
 MicroCellPosition Param::get_micro_cell_position_from_cell_index(int cell_index) const {

--- a/src/Param.h
+++ b/src/Param.h
@@ -24,7 +24,8 @@ struct DomainSize
 /// Parameters used by the simulation.
 struct Param
 {
-	int PopSize; /**< Population size */
+    /// Size of the population (unit: number of people).
+	int population_size;
 	int NH; // Number of households
 	int NumRealisations; /**< Number of Realisations */
 	int NumNonExtinctRealisations; /**< Number of non-extinct realisations */

--- a/src/Param.h
+++ b/src/Param.h
@@ -43,8 +43,8 @@ struct Param
 	/// Actual number of realisations.
 	int actual_realisations_count;
 
-	// TODO(jieyouxu): document and rename this parameter.
-	int NRactE;
+	/// Actual number of extinct realisations.
+	int actual_extinct_realisations_count;
 
 	// TODO(jieyouxu): document and rename this parameter.
 	int NRactNE;

--- a/src/Param.h
+++ b/src/Param.h
@@ -55,6 +55,7 @@ struct Param
 	/// Total number of samples that will be made. (unit: number of samples).
 	int samples_count;
 
+	/// Type of the kernel.
 	// TODO(jieyouxu): refactor this into an enum. This is an ideal candidate for a compile-time function lookup table.
 	int KernelType;
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -55,7 +55,9 @@ struct Param
 	/// Total number of samples that will be made. (unit: number of samples).
 	int samples_count;
 
+	// TODO(jieyouxu): refactor this into an enum. This is an ideal candidate for a compile-time function lookup table.
 	int KernelType;
+
 	int NKR; // Size of kernel lookup table
 	int NK_HR; // Factor to expand hi-res kernel lookup table by
 	int MoveKernelType;

--- a/src/Param.h
+++ b/src/Param.h
@@ -72,9 +72,11 @@ struct Param
 	/// Size of the binary file buffer (unit: bytes).
 	unsigned int binary_file_size;
 
-	int DoSaveSnapshot;
-	int DoLoadSnapshot;
 	int DoBin;
+	/// Should we save snapshots of the run?
+	int save_snapshots;
+	/// Should we load snapshots of the run?
+	int load_snapshots;
 
 	double clP1, clP2, clP3, clP4, clP5, clP6;
 	double SnapshotLoadTime;

--- a/src/Param.h
+++ b/src/Param.h
@@ -69,10 +69,11 @@ struct Param
 	int MoveKernelType;
 	int AirportKernelType;
 
-	/// Size of the binary file buffer (unit: bytes).
-	unsigned int binary_file_size;
+	/// Number of lines of the binary file buffer (unit: lines).
+	unsigned int binary_file_lines_count;
 
 	int DoBin;
+
 	/// Should we save snapshots of the run?
 	int save_snapshots;
 	/// Should we load snapshots of the run?

--- a/src/Param.h
+++ b/src/Param.h
@@ -127,7 +127,10 @@ struct Param
 	/// See <https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system>.
 	int use_utm_coordinate_system;
 
-	int DoSeasonality;
+	/// Should the simulation take into account seasonality, where some variations occur at predictable, regular
+	/// intervals within a year (such as average temperature changes)?
+	int respect_seasonality_variations;
+
 	int DoCorrectAgeDist;
 	int DoPartialImmunity;
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -34,7 +34,12 @@ struct Param
 	///
 	/// A *realisation* is an observation of the random simulation generated from the same input parameters.
 	int realisations_count;
-	int NumNonExtinctRealisations; /**< Number of non-extinct realisations */
+
+	/// Number of non-extinct realisations (unit: number of *non-extinct* realisations).
+	///
+	/// A realisation is *non-extinct* if the disease does *not* die out.
+	int non_extinct_realisations_count;
+
 	int NRactual;
 	int NRactE;
 	int NRactNE;

--- a/src/Param.h
+++ b/src/Param.h
@@ -46,8 +46,8 @@ struct Param
 	/// Actual number of extinct realisations.
 	int actual_extinct_realisations_count;
 
-	// TODO(jieyouxu): document and rename this parameter.
-	int NRactNE;
+	/// Actual number of non-extinct realisations.
+	int actual_non_extinct_realisations_count;
 
 	/// Number of time steps between samples (unit: number of time steps between samples).
 	int time_steps_between_samples;

--- a/src/Param.h
+++ b/src/Param.h
@@ -40,8 +40,8 @@ struct Param
 	/// A realisation is *non-extinct* if the disease does *not* die out.
 	int non_extinct_realisations_count;
 
-	// TODO(jieyouxu): document and rename this parameter.
-	int NRactual;
+	/// Actual number of realisations.
+	int actual_realisations_count;
 
 	// TODO(jieyouxu): document and rename this parameter.
 	int NRactE;

--- a/src/Param.h
+++ b/src/Param.h
@@ -95,7 +95,14 @@ struct Param
 	/// Number of microcells. A cell may contain multiple microcells.
 	int microcells_count;
 
-	int NMCL; // Number of microcells wide/high a cell is; i.e. microcells_count = NC * NMCL * NMCL
+	/// Length of a cell (unit: microcells).
+	///
+	/// Each cell is a square grid of microcells. Let `n` be the number of microcells, then each cell is occupied by
+	/// `n * n` microcells (i.e. the cell is `n` microcells wide, `n` microcells tall).
+	///
+	/// `microcells_count` is computed by `cells_count * cell_length_microcells^2`.
+	int cell_length_microcells;
+
 	int NCP; /**< Number of populated cells  */
 	int NMCP, ncw, nch, DoUTM_coords, nsp, DoSeasonality, DoCorrectAgeDist, DoPartialImmunity;
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -92,8 +92,10 @@ struct Param
 	/// Number of cells.
 	int cells_count;
 
-	int NMC; // Number of microcells
-	int NMCL; // Number of microcells wide/high a cell is; i.e. NMC = NC * NMCL * NMCL
+	/// Number of microcells. A cell may contain multiple microcells.
+	int microcells_count;
+
+	int NMCL; // Number of microcells wide/high a cell is; i.e. microcells_count = NC * NMCL * NMCL
 	int NCP; /**< Number of populated cells  */
 	int NMCP, ncw, nch, DoUTM_coords, nsp, DoSeasonality, DoCorrectAgeDist, DoPartialImmunity;
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -72,6 +72,8 @@ struct Param
 	/// Number of lines of the binary file buffer (unit: lines).
 	unsigned int binary_file_lines_count;
 
+	/// Should we enable binary output?
+	// TODO(jieyouxu): this really should be a `bool`, but there is a `P.DoBin = -1` assignment in `SetupModel`.
 	int DoBin;
 
 	/// Should we save snapshots of the run?

--- a/src/Param.h
+++ b/src/Param.h
@@ -89,7 +89,9 @@ struct Param
 	double snapshot_load_time;
 	double snapshot_save_time;
 
-	int NC; // Number of cells
+	/// Number of cells.
+	int cells_count;
+
 	int NMC; // Number of microcells
 	int NMCL; // Number of microcells wide/high a cell is; i.e. NMC = NC * NMCL * NMCL
 	int NCP; /**< Number of populated cells  */

--- a/src/Param.h
+++ b/src/Param.h
@@ -65,8 +65,10 @@ struct Param
 	/// High-resolution kernel look up table expansion scaling factor.
 	int high_resolution_kernel_lookup_table_expansion_factor;
 
+	// TODO(jieyouxu): refactor these two parameters to use same enum as `KernelType`.
 	int MoveKernelType;
 	int AirportKernelType;
+
 	unsigned int BinFileLen;
 	int DoBin, DoSaveSnapshot, DoLoadSnapshot;
 	double SnapshotSaveTime, SnapshotLoadTime, clP1, clP2, clP3, clP4, clP5, clP6;

--- a/src/Param.h
+++ b/src/Param.h
@@ -109,8 +109,12 @@ struct Param
 	/// Number of populated microcells.
 	int populated_microcells_count;
 
-	int ncw;
-	int nch;
+	/// Width of the simulation cell grid (unit: cells).
+	int cell_grid_width;
+
+	/// Height of the simulation cell grid (unit: cells).
+	int cell_grid_height;
+
 	int nsp;
 
 	int DoUTM_coords;

--- a/src/Param.h
+++ b/src/Param.h
@@ -134,7 +134,9 @@ struct Param
 	/// Should the simulation attempt to correct age distributions?
 	int should_correct_age_distributions;
 
-	int DoPartialImmunity;
+	/// Should the simulation take into account the possible existence of partial immunity within a population, that
+	/// some people may be naturally immune to a virus?
+	int respect_partial_immunity;
 
 	int get_number_of_micro_cells_wide() const;
 	int get_number_of_micro_cells_high() const;

--- a/src/Param.h
+++ b/src/Param.h
@@ -21,10 +21,7 @@ struct DomainSize
 	double height_;
 };
 
-/**
- * @brief Stores the parameters for the simulation.
- *
- */
+/// Parameters used by the simulation.
 struct Param
 {
 	int PopSize; /**< Population size */

--- a/src/Param.h
+++ b/src/Param.h
@@ -26,9 +26,14 @@ struct Param
 {
     /// Size of the population (unit: number of people).
 	int population_size;
+
 	/// Number of households (unit: number of households).
 	int households_count;
-	int NumRealisations; /**< Number of Realisations */
+
+	/// Number of realisations (unit: number of realisations).
+	///
+	/// A *realisation* is an observation of the random simulation generated from the same input parameters.
+	int realisations_count;
 	int NumNonExtinctRealisations; /**< Number of non-extinct realisations */
 	int NRactual;
 	int NRactE;

--- a/src/Param.h
+++ b/src/Param.h
@@ -103,7 +103,9 @@ struct Param
 	/// `microcells_count` is computed by `cells_count * cell_length_microcells^2`.
 	int cell_length_microcells;
 
-	int NCP; /**< Number of populated cells  */
+	/// Number of populated cells.
+	int populated_cells_count;
+
 	int NMCP, ncw, nch, DoUTM_coords, nsp, DoSeasonality, DoCorrectAgeDist, DoPartialImmunity;
 
 	int get_number_of_micro_cells_wide() const;

--- a/src/Param.h
+++ b/src/Param.h
@@ -69,7 +69,9 @@ struct Param
 	int MoveKernelType;
 	int AirportKernelType;
 
-	unsigned int BinFileLen;
+	/// Size of the binary file buffer (unit: bytes).
+	unsigned int binary_file_size;
+
 	int DoBin, DoSaveSnapshot, DoLoadSnapshot;
 	double SnapshotSaveTime, SnapshotLoadTime, clP1, clP2, clP3, clP4, clP5, clP6;
 	int NC; // Number of cells

--- a/src/Param.h
+++ b/src/Param.h
@@ -85,8 +85,10 @@ struct Param
 	// TODO(jieyouxu): document and rename these magic variables.
 	double clP1, clP2, clP3, clP4, clP5, clP6;
 
+	// TODO(jieyouxu): document their purpose and units, pending rename.
 	double SnapshotLoadTime;
 	double SnapshotSaveTime;
+
 	int NC; // Number of cells
 	int NMC; // Number of microcells
 	int NMCL; // Number of microcells wide/high a cell is; i.e. NMC = NC * NMCL * NMCL

--- a/src/Param.h
+++ b/src/Param.h
@@ -49,7 +49,9 @@ struct Param
 	// TODO(jieyouxu): document and rename this parameter.
 	int NRactNE;
 
-	int UpdatesPerSample; // Number of time steps between samples
+	/// Number of time steps between samples (unit: number of time steps between samples).
+	int time_steps_between_samples;
+
 	int NumSamples; // Total number of samples that will be made
 	int KernelType;
 	int NKR; // Size of kernel lookup table

--- a/src/Param.h
+++ b/src/Param.h
@@ -72,8 +72,13 @@ struct Param
 	/// Size of the binary file buffer (unit: bytes).
 	unsigned int binary_file_size;
 
-	int DoBin, DoSaveSnapshot, DoLoadSnapshot;
-	double SnapshotSaveTime, SnapshotLoadTime, clP1, clP2, clP3, clP4, clP5, clP6;
+	int DoSaveSnapshot;
+	int DoLoadSnapshot;
+	int DoBin;
+
+	double clP1, clP2, clP3, clP4, clP5, clP6;
+	double SnapshotLoadTime;
+	double SnapshotSaveTime;
 	int NC; // Number of cells
 	int NMC; // Number of microcells
 	int NMCL; // Number of microcells wide/high a cell is; i.e. NMC = NC * NMCL * NMCL

--- a/src/Param.h
+++ b/src/Param.h
@@ -40,9 +40,15 @@ struct Param
 	/// A realisation is *non-extinct* if the disease does *not* die out.
 	int non_extinct_realisations_count;
 
+	// TODO(jieyouxu): document and rename this parameter.
 	int NRactual;
+
+	// TODO(jieyouxu): document and rename this parameter.
 	int NRactE;
+
+	// TODO(jieyouxu): document and rename this parameter.
 	int NRactNE;
+
 	int UpdatesPerSample; // Number of time steps between samples
 	int NumSamples; // Total number of samples that will be made
 	int KernelType;

--- a/src/Param.h
+++ b/src/Param.h
@@ -118,7 +118,8 @@ struct Param
 	/// Height of the simulation cell grid (unit: cells).
 	int cell_grid_height;
 
-	int nsp;
+	/// Number of different types of schools.
+	int school_types_count;
 
 	int DoUTM_coords;
 	int DoSeasonality;

--- a/src/Param.h
+++ b/src/Param.h
@@ -86,8 +86,8 @@ struct Param
 	double clP1, clP2, clP3, clP4, clP5, clP6;
 
 	// TODO(jieyouxu): document their purpose and units, pending rename.
-	double SnapshotLoadTime;
-	double SnapshotSaveTime;
+	double snapshot_load_time;
+	double snapshot_save_time;
 
 	int NC; // Number of cells
 	int NMC; // Number of microcells

--- a/src/Param.h
+++ b/src/Param.h
@@ -78,10 +78,13 @@ struct Param
 
 	/// Should we save snapshots of the run?
 	int save_snapshots;
+
 	/// Should we load snapshots of the run?
 	int load_snapshots;
 
+	// TODO(jieyouxu): document and rename these magic variables.
 	double clP1, clP2, clP3, clP4, clP5, clP6;
+
 	double SnapshotLoadTime;
 	double SnapshotSaveTime;
 	int NC; // Number of cells

--- a/src/Param.h
+++ b/src/Param.h
@@ -26,7 +26,8 @@ struct Param
 {
     /// Size of the population (unit: number of people).
 	int population_size;
-	int NH; // Number of households
+	/// Number of households (unit: number of households).
+	int households_count;
 	int NumRealisations; /**< Number of Realisations */
 	int NumNonExtinctRealisations; /**< Number of non-extinct realisations */
 	int NRactual;

--- a/src/Param.h
+++ b/src/Param.h
@@ -74,7 +74,7 @@ struct Param
 
 	/// Should we enable binary output?
 	// TODO(jieyouxu): this really should be a `bool`, but there is a `P.DoBin = -1` assignment in `SetupModel`.
-	int DoBin;
+	int enable_binary_output;
 
 	/// Should we save snapshots of the run?
 	int save_snapshots;

--- a/src/Param.h
+++ b/src/Param.h
@@ -62,7 +62,9 @@ struct Param
 	// TODO(jieyouxu): determine the units.
 	int kernel_lookup_table_size;
 
-	int NK_HR; // Factor to expand hi-res kernel lookup table by
+	/// High-resolution kernel look up table expansion scaling factor.
+	int high_resolution_kernel_lookup_table_expansion_factor;
+
 	int MoveKernelType;
 	int AirportKernelType;
 	unsigned int BinFileLen;

--- a/src/Param.h
+++ b/src/Param.h
@@ -52,7 +52,9 @@ struct Param
 	/// Number of time steps between samples (unit: number of time steps between samples).
 	int time_steps_between_samples;
 
-	int NumSamples; // Total number of samples that will be made
+	/// Total number of samples that will be made. (unit: number of samples).
+	int samples_count;
+
 	int KernelType;
 	int NKR; // Size of kernel lookup table
 	int NK_HR; // Factor to expand hi-res kernel lookup table by

--- a/src/Param.h
+++ b/src/Param.h
@@ -83,7 +83,9 @@ struct Param
 	/// Should we load snapshots of the run?
 	int load_snapshots;
 
-	// TODO(jieyouxu): document and rename these magic variables.
+	/// Special tuning parameters which interact with wildcards in the intervention parameters. These parameters are
+	/// used to vary parts of parameters at run-time (e.g. to undertake sensitivity analysis) without needing to
+	/// generate new parameter files.
 	double clP1, clP2, clP3, clP4, clP5, clP6;
 
 	// TODO(jieyouxu): document their purpose and units, pending rename.

--- a/src/Param.h
+++ b/src/Param.h
@@ -121,7 +121,12 @@ struct Param
 	/// Number of different types of schools.
 	int school_types_count;
 
-	int DoUTM_coords;
+	/// Should the simulation use the Universal Transverse Mercator (UTM) coordinate system, which assigns coordinates
+	/// to locations on the surface of Earth?
+	///
+	/// See <https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system>.
+	int use_utm_coordinate_system;
+
 	int DoSeasonality;
 	int DoCorrectAgeDist;
 	int DoPartialImmunity;

--- a/src/Param.h
+++ b/src/Param.h
@@ -106,7 +106,8 @@ struct Param
 	/// Number of populated cells.
 	int populated_cells_count;
 
-	int NMCP, ncw, nch, DoUTM_coords, nsp, DoSeasonality, DoCorrectAgeDist, DoPartialImmunity;
+	/// Number of populated microcells.
+	int populated_microcells_count;
 
 	int get_number_of_micro_cells_wide() const;
 	int get_number_of_micro_cells_high() const;

--- a/src/Param.h
+++ b/src/Param.h
@@ -131,7 +131,9 @@ struct Param
 	/// intervals within a year (such as average temperature changes)?
 	int respect_seasonality_variations;
 
-	int DoCorrectAgeDist;
+	/// Should the simulation attempt to correct age distributions?
+	int should_correct_age_distributions;
+
 	int DoPartialImmunity;
 
 	int get_number_of_micro_cells_wide() const;

--- a/src/Param.h
+++ b/src/Param.h
@@ -58,7 +58,10 @@ struct Param
 	// TODO(jieyouxu): refactor this into an enum. This is an ideal candidate for a compile-time function lookup table.
 	int KernelType;
 
-	int NKR; // Size of kernel lookup table
+	/// Size of the default-resolution kernel lookup table.
+	// TODO(jieyouxu): determine the units.
+	int kernel_lookup_table_size;
+
 	int NK_HR; // Factor to expand hi-res kernel lookup table by
 	int MoveKernelType;
 	int AirportKernelType;

--- a/src/Param.h
+++ b/src/Param.h
@@ -109,6 +109,15 @@ struct Param
 	/// Number of populated microcells.
 	int populated_microcells_count;
 
+	int ncw;
+	int nch;
+	int nsp;
+
+	int DoUTM_coords;
+	int DoSeasonality;
+	int DoCorrectAgeDist;
+	int DoPartialImmunity;
+
 	int get_number_of_micro_cells_wide() const;
 	int get_number_of_micro_cells_high() const;
 	MicroCellPosition get_micro_cell_position_from_cell_index(int cell_index) const;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -204,9 +204,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	if (tw > t) t = tw;
 	if (th > t) t = th;
 	if (P.DoPeriodicBoundaries) t *= 0.25;
-	if (!(nKernel = (double*)calloc(P.NKR + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");
-	if (!(nKernelHR = (double*)calloc(P.NKR + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");
-	P.KernelDelta = t / P.NKR;
+	if (!(nKernel = (double*)calloc(P.kernel_lookup_table_size + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");
+	if (!(nKernelHR = (double*)calloc(P.kernel_lookup_table_size + 1, sizeof(double)))) ERR_CRITICAL("Unable to allocate kernel storage\n");
+	P.KernelDelta = t / P.kernel_lookup_table_size;
 	//	fprintf(stderr,"** %i %lg %lg %lg %lg | %lg %lg %lg %lg \n",P.DoUTM_coords,P.SpatialBoundingBox[0],P.SpatialBoundingBox[1],P.SpatialBoundingBox[2],P.SpatialBoundingBox[3],P.width,P.height,t,P.KernelDelta);
 	fprintf(stderr, "Coords xmcell=%lg m   ymcell = %lg m\n",
 		sqrt(dist2_raw(P.in_degrees_.width_ / 2, P.in_degrees_.height_ / 2, P.in_degrees_.width_ / 2 + P.in_microcells_.width_, P.in_degrees_.height_ / 2)),

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -417,7 +417,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 				shared(P, Households, Hosts)
 			for (int tn = 0; tn < P.NumThreads; tn++)
 			{
-				for (int i = tn; i < P.NH; i += P.NumThreads)
+				for (int i = tn; i < P.households_count; i += P.NumThreads)
 				{
 					if (ranf_mt(tn) < P.PropPopUsingDigitalContactTracing)
 					{
@@ -443,7 +443,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			}
 			P.NDigitalContactUsers = l;
 			P.NDigitalHouseholdUsers = m;
-			fprintf(stderr, "Number of digital contact tracing households: %i, out of total number of households: %i\n", P.NDigitalHouseholdUsers, P.NH);
+			fprintf(stderr, "Number of digital contact tracing households: %i, out of total number of households: %i\n", P.NDigitalHouseholdUsers, P.households_count);
 			fprintf(stderr, "Number of digital contact tracing users: %i, out of population size: %i\n", P.NDigitalContactUsers, P.population_size);
 		}
 		else // Just go through the population and assign people to the digital contact tracing app based on probability by age.
@@ -626,7 +626,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	for (int i = 0; i < P.population_size; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
 	if (P.EnhancedSocDistClusterByHousehold)
 	{
-		for (int i = 0; i < P.NH;i++)
+		for (int i = 0; i < P.households_count; i++)
 		{
 			l = Households[i].FirstPerson;
 			m = l + Households[i].nh;
@@ -1084,7 +1084,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	}
 	fprintf(stderr, "Cells assigned\n");
 	for (int i = 0; i <= MAX_HOUSEHOLD_SIZE; i++) denom_household[i] = 0;
-	P.NH = 0;
+	P.households_count = 0;
 	int numberOfPeople = 0;
 	for (j2 = 0; j2 < P.NMCP; j2++)
 	{
@@ -1109,14 +1109,14 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 				Cells[l].members[Cells[l].cumTC++] = numberOfPeople + i2;
 				Hosts[numberOfPeople + i2].pcell = l;
 				Hosts[numberOfPeople + i2].mcell = j;
-				Hosts[numberOfPeople + i2].hh = P.NH;
+				Hosts[numberOfPeople + i2].hh = P.households_count;
 			}
-			P.NH++;
+			P.households_count++;
 			numberOfPeople += m;
 			k += m;
 		}
 	}
-	if (!(Households = (Household*)malloc(P.NH * sizeof(Household)))) ERR_CRITICAL("Unable to allocate household storage\n");
+	if (!(Households = (Household*)malloc(P.households_count * sizeof(Household)))) ERR_CRITICAL("Unable to allocate household storage\n");
 	for (j = 0; j < NUM_AGE_GROUPS; j++) AgeDist[j] = AgeDist2[j] = 0;
 	if (P.DoHouseholds) fprintf(stderr, "Household sizes assigned to %i people\n", numberOfPeople);
 

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -36,7 +36,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	P.nextSetupSeed2 = P.setupSeed2;
 	setall(&P.nextSetupSeed1, &P.nextSetupSeed2);
 
-	P.DoBin = -1;
+	P.enable_binary_output = -1;
 	if (P.DoHeteroDensity)
 	{
 		fprintf(stderr, "Scanning population density file\n");
@@ -45,7 +45,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		fread_big(&density_file_header, sizeof(unsigned int), 1, dat);
 		if (density_file_header == 0xf0f0f0f0) //code for first 4 bytes of binary file ## NOTE - SHOULD BE LONG LONG TO COPE WITH BIGGER POPULATIONS
 		{
-			P.DoBin = 1;
+			P.enable_binary_output = 1;
 			fread_big(&(P.binary_file_lines_count), sizeof(unsigned int), 1, dat);
 			if (!(BinFileBuf = (void*)malloc(P.binary_file_lines_count * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
 			fread_big(BinFileBuf, sizeof(BinFile), (size_t)P.binary_file_lines_count, dat);
@@ -54,7 +54,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		}
 		else
 		{
-			P.DoBin = 0;
+			P.enable_binary_output = 0;
 			// Count the number of lines in the density file
 			rewind(dat);
 			P.binary_file_lines_count = 0;
@@ -798,7 +798,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 					}
 					else
 						mcell_adunits[l] = 0;
-					if ((P.OutputDensFile) && (P.DoBin) && (mcell_adunits[l] >= 0))
+					if ((P.OutputDensFile) && (P.enable_binary_output) && (mcell_adunits[l] >= 0))
 					{
 						if (rn2 < rn) BF[rn2] = rec;
 						rn2++;
@@ -808,13 +808,13 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		}
 		//		fclose(dat2);
 		fprintf(stderr, "%i valid microcells read from density file.\n", mr);
-		if ((P.OutputDensFile) && (P.DoBin)) P.binary_file_lines_count = rn2;
-		if (P.DoBin == 0)
+		if ((P.OutputDensFile) && (P.enable_binary_output)) P.binary_file_lines_count = rn2;
+		if (P.enable_binary_output == 0)
 		{
 			if (P.OutputDensFile)
 			{
 				free(BinFileBuf);
-				P.DoBin = 1;
+				P.enable_binary_output = 1;
 				P.binary_file_lines_count = 0;
 				for (l = 0; l < P.microcells_count; l++)
 					if (mcell_adunits[l] >= 0) P.binary_file_lines_count++;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -150,9 +150,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.in_degrees_.height_ = ((double)P.nch) * P.in_cells_.height_;
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[0] + P.in_degrees_.width_;
 		P.SpatialBoundingBox[3] = P.SpatialBoundingBox[1] + P.in_degrees_.height_;
-		P.NC = P.ncw * P.nch;
+		P.cells_count = P.ncw * P.nch;
 		fprintf(stderr, "Adjusted bounding box = (%lg, %lg)- (%lg, %lg)\n", P.SpatialBoundingBox[0], P.SpatialBoundingBox[1], P.SpatialBoundingBox[2], P.SpatialBoundingBox[3]);
-		fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.NC, P.ncw, P.nch);
+		fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.cells_count, P.ncw, P.nch);
 		fprintf(stderr, "Population size = %i \n", P.population_size);
 		if (P.in_degrees_.width_ > 180) {
 			fprintf(stderr, "WARNING: Width of bounding box > 180 degrees.  Results may be inaccurate.\n");
@@ -165,9 +165,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	}
 	else
 	{
-		P.ncw = P.nch = (int)sqrt((double)P.NC);
-		P.NC = P.ncw * P.nch;
-		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.NC, P.ncw);
+		P.ncw = P.nch = (int)sqrt((double)P.cells_count);
+		P.cells_count = P.ncw * P.nch;
+		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.cells_count, P.ncw);
 		s = floor(sqrt((double)P.population_size));
 		P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 0;
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = s;
@@ -177,7 +177,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
 		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);
 	}
-	P.NMC = P.NMCL * P.NMCL * P.NC;
+	P.NMC = P.NMCL * P.NMCL * P.cells_count;
 	fprintf(stderr, "Number of microcells = %i\n", P.NMC);
 	P.scalex = P.BitmapScale;
 	P.scaley = P.BitmapAspectScale * P.BitmapScale;
@@ -312,7 +312,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	setall(&P.nextSetupSeed1, &P.nextSetupSeed2);
 
 	StratifyPlaces();
-	for (int i = 0; i < P.NC; i++)
+	for (int i = 0; i < P.cells_count; i++)
 	{
 		Cells[i].S = Cells[i].n;
 		Cells[i].L = Cells[i].I = Cells[i].R = 0;
@@ -621,7 +621,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		for (int j = 0; j <= MAX_HOUSEHOLD_SIZE; j++)
 			inf_household_av[i][j] = case_household_av[i][j] = 0;
 	DoInitUpdateProbs = 1;
-	for (int i = 0; i < P.NC; i++)	Cells[i].tot_treat = 1;  //This makes sure InitModel intialises the cells.
+	for (int i = 0; i < P.cells_count; i++) Cells[i].tot_treat = 1;  //This makes sure InitModel intialises the cells.
 	P.NRactE = P.NRactNE = 0;
 	for (int i = 0; i < P.population_size; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
 	if (P.EnhancedSocDistClusterByHousehold)
@@ -712,7 +712,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	double *mcell_dens;
 	int *mcell_adunits, *mcell_num, *mcell_country;
 
-	if (!(Cells = (Cell*)calloc(P.NC, sizeof(Cell)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+	if (!(Cells = (Cell*)calloc(P.cells_count, sizeof(Cell)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	if (!(Mcells = (Microcell*)calloc(P.NMC, sizeof(Microcell)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 	if (!(mcell_num = (int*)malloc(P.NMC * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 	if (!(mcell_dens = (double*)malloc(P.NMC * sizeof(double)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
@@ -1026,7 +1026,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	if (!(McellLookup = (Microcell * *)malloc(P.NMCP * sizeof(Microcell*)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 	if (!(State.CellMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	P.NCP = 0;
-	for (int i = i2 = j2 = 0; i < P.NC; i++)
+	for (int i = i2 = j2 = 0; i < P.cells_count; i++)
 	{
 		Cells[i].n = 0;
 		int k = (i / P.nch) * P.NMCL * P.get_number_of_micro_cells_high() + (i % P.nch) * P.NMCL;
@@ -1055,7 +1055,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	if (!(State.CellSuscMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	int susceptibleAccumulator = 0;
 	i2 = 0;
-	for (j = 0; j < P.NC; j++)
+	for (j = 0; j < P.cells_count; j++)
 		if (Cells[j].n > 0)
 		{
 			CellLookup[i2++] = Cells + j;
@@ -1077,7 +1077,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			if (!(c->cum_trans = (float*)malloc(P.NCP * sizeof(float)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 		}
 	}
-	for (int i = 0; i < P.NC; i++)
+	for (int i = 0; i < P.cells_count; i++)
 	{
 		Cells[i].cumTC = 0;
 		for (j = 0; j < Cells[i].n; j++) Cells[i].members[j] = -1;
@@ -1442,7 +1442,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 */		fprintf(stderr, "Places assigned\n");
 	}
 	l = 0;
-	for (j = 0; j < P.NC; j++)
+	for (j = 0; j < P.cells_count; j++)
 		if (l < Cells[j].n) l = Cells[j].n;
 	if (!(SamplingQueue = (int**)malloc(P.NumThreads * sizeof(int*)))) ERR_CRITICAL("Unable to allocate state storage\n");
 	P.InfQueuePeakLength = P.population_size / P.NumThreads / INF_QUEUE_SCALE;
@@ -1491,7 +1491,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		}
 	}
 
-	for (int i = 0; i < P.NC; i++)
+	for (int i = 0; i < P.cells_count; i++)
 	{
 		Cells[i].cumTC = 0;
 		Cells[i].S = Cells[i].n;
@@ -1868,7 +1868,7 @@ void AssignPeopleToPlaces()
 	if (P.DoPlaces)
 	{
 		fprintf(stderr, "Assigning people to places....\n");
-		for (int i = 0; i < P.NC; i++)
+		for (int i = 0; i < P.cells_count; i++)
 		{
 			Cells[i].infected = Cells[i].susceptible;
 			if (!(Cells[i].susceptible = (int*)calloc(Cells[i].n, sizeof(int)))) ERR_CRITICAL("Unable to allocate state storage\n");
@@ -1982,7 +1982,7 @@ void AssignPeopleToPlaces()
 							k = j * P.nch + ((int)(Places[tp][i].loc_y / P.in_cells_.height_));
 							Cells[k].I += (int)Places[tp][i].treat_end_time;
 						}
-					for (k = 0; k < P.NC; k++)
+					for (k = 0; k < P.cells_count; k++)
 					{
 						int i = k % P.nch;
 						j = k / P.nch;
@@ -2022,7 +2022,7 @@ void AssignPeopleToPlaces()
 						Cells[k].L = f3; Cells[k].R = f2;
 					}
 					m = f2 = f3 = f4 = 0;
-					for (k = 0; k < P.NC; k++)
+					for (k = 0; k < P.cells_count; k++)
 						if ((Cells[k].S > 0) && (Cells[k].I == 0))
 						{
 							f2 += Cells[k].S; f3++;
@@ -2041,7 +2041,7 @@ void AssignPeopleToPlaces()
 							}
 							m += ((int)Places[tp][i].treat_end_time);
 						}
-					for (int i = 0; i < P.NC; i++) Cells[i].L = Cells[i].I = Cells[i].R = 0;
+					for (int i = 0; i < P.cells_count; i++) Cells[i].L = Cells[i].I = Cells[i].R = 0;
 				}
 				t = ((double)m) / ((double)P.Nplace[tp]);
 				fprintf(stderr, "Adjusting place weights (Capacity=%i Demand=%i  Av place size=%lg)\n", m, cnt, t);
@@ -2067,13 +2067,13 @@ void AssignPeopleToPlaces()
 				}
 				if (P.PlaceTypeNearestNeighb[tp] == 0)
 				{
-					for (int i = 0; i < P.NC; i++) Cells[i].S = 0;
+					for (int i = 0; i < P.cells_count; i++) Cells[i].S = 0;
 					for (j = 0; j < P.Nplace[tp]; j++)
 					{
 						int i = P.nch * ((int)(Places[tp][j].loc_x / P.in_cells_.width_)) + ((int)(Places[tp][j].loc_y / P.in_cells_.height_));
 						Cells[i].S += (int)Places[tp][j].treat_end_time;
 					}
-					for (int i = 0; i < P.NC; i++)
+					for (int i = 0; i < P.cells_count; i++)
 					{
 						if (Cells[i].S > Cells[i].cumTC)
 						{
@@ -2313,7 +2313,7 @@ void AssignPeopleToPlaces()
 				}
 			}
 		}
-		for (int i = 0; i < P.NC; i++)
+		for (int i = 0; i < P.cells_count; i++)
 		{
 			Cells[i].n = Cells[i].cumTC;
 			Cells[i].cumTC = 0;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -215,17 +215,17 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 
 	SetupPopulation(SchoolFile, RegDemogFile);
 
-	if (!(TimeSeries = (Results*)calloc(P.NumSamples, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
-	if (!(TSMeanE = (Results*)calloc(P.NumSamples, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
-	if (!(TSVarE = (Results*)calloc(P.NumSamples, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
-	if (!(TSMeanNE = (Results*)calloc(P.NumSamples, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
-	if (!(TSVarNE = (Results*)calloc(P.NumSamples, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
+	if (!(TimeSeries = (Results*)calloc(P.samples_count, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
+	if (!(TSMeanE = (Results*)calloc(P.samples_count, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
+	if (!(TSVarE = (Results*)calloc(P.samples_count, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
+	if (!(TSMeanNE = (Results*)calloc(P.samples_count, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
+	if (!(TSVarNE = (Results*)calloc(P.samples_count, sizeof(Results)))) ERR_CRITICAL("Unable to allocate results storage\n");
 	TSMean = TSMeanE; TSVar = TSVarE;
 	///// This loops over index l twice just to reset the pointer TSMean from TSMeanE to TSMeanNE (same for TSVar).
 	int num_in_results = sizeof(Results) / sizeof(double);
 	for (l = 0; l < 2; l++)
 	{
-		for (int i = 0; i < P.NumSamples; i++)
+		for (int i = 0; i < P.samples_count; i++)
 		{
 			double *ts_mean = (double *)&TSMean[i];
 			double *ts_var = (double *)&TSVar[i];
@@ -258,7 +258,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		}
 
 		// initialize TimeSeries age and admin unit breakdowns
-		for (int Time = 0; Time < P.NumSamples; Time++)
+		for (int Time = 0; Time < P.samples_count; Time++)
 		{
 			TimeSeries[Time].prevInf_age_adunit = new double* [NUM_AGE_GROUPS]();
 			TimeSeries[Time].incInf_age_adunit = new double* [NUM_AGE_GROUPS]();

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -622,7 +622,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			inf_household_av[i][j] = case_household_av[i][j] = 0;
 	DoInitUpdateProbs = 1;
 	for (int i = 0; i < P.cells_count; i++) Cells[i].tot_treat = 1;  //This makes sure InitModel intialises the cells.
-	P.NRactE = P.NRactNE = 0;
+	P.actual_extinct_realisations_count = P.NRactNE = 0;
 	for (int i = 0; i < P.population_size; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
 	if (P.EnhancedSocDistClusterByHousehold)
 	{

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -497,9 +497,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		for (int i = tn; i < P.population_size; i += P.NumThreads)
 		{
 			if (P.SusceptibilitySD == 0)
-				Hosts[i].susc = (float)((P.DoPartialImmunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(i)]) : 1.0);
+				Hosts[i].susc = (float)((P.respect_partial_immunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(i)]) : 1.0);
 			else
-				Hosts[i].susc = (float) (((P.DoPartialImmunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(i)]) : 1.0) * gen_gamma_mt(1 / (P.SusceptibilitySD * P.SusceptibilitySD), 1 / (P.SusceptibilitySD * P.SusceptibilitySD), tn));
+				Hosts[i].susc = (float) (((P.respect_partial_immunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(i)]) : 1.0) * gen_gamma_mt(1 / (P.SusceptibilitySD * P.SusceptibilitySD), 1 / (P.SusceptibilitySD * P.SusceptibilitySD), tn));
 			if (P.InfectiousnessSD == 0)
 				Hosts[i].infectiousness = (float)P.AgeInfectiousness[HOST_AGE_GROUP(i)];
 			else

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1314,15 +1314,15 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		else
 			free(State.InvAgeDist[0]);
 		free(State.InvAgeDist);
-	*/	P.nsp = 0;
+	*/	P.school_types_count = 0;
 	if (P.DoPlaces)
 		if (!(Places = (Place * *)malloc(P.PlaceTypeNum * sizeof(Place*)))) ERR_CRITICAL("Unable to allocate place storage\n");
 	if ((P.DoSchoolFile) && (P.DoPlaces))
 	{
 		fprintf(stderr, "Reading school file\n");
 		if (!(dat = fopen(SchoolFile, "rb"))) ERR_CRITICAL("Unable to open school file\n");
-		fscanf(dat, "%i", &P.nsp);
-		for (j = 0; j < P.nsp; j++)
+		fscanf(dat, "%i", &P.school_types_count);
+		for (j = 0; j < P.school_types_count; j++)
 		{
 			fscanf(dat, "%i %i", &m, &(P.PlaceTypeMaxAgeRead[j]));
 			if (!(Places[j] = (Place*)calloc(m, sizeof(Place)))) ERR_CRITICAL("Unable to allocate place storage\n");
@@ -1355,13 +1355,13 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		fclose(dat);
 		fprintf(stderr, "%i schools read (%i in empty cells)      \n", P.Nplace[j], mr);
 		for (int i = 0; i < P.microcells_count; i++)
-			for (j = 0; j < P.nsp; j++)
+			for (j = 0; j < P.school_types_count; j++)
 				if (Mcells[i].np[j] > 0)
 				{
 					if (!(Mcells[i].places[j] = (int*)malloc(Mcells[i].np[j] * sizeof(int)))) ERR_CRITICAL("Unable to allocate place storage\n");
 					Mcells[i].np[j] = 0;
 				}
-		for (j = 0; j < P.nsp; j++)
+		for (j = 0; j < P.school_types_count; j++)
 		{
 			t = s = 0;
 			for (int i = 0; i < P.population_size; i++)
@@ -1386,7 +1386,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 #pragma omp parallel for private(j2,j,t,m,s,x,y,xh,yh) schedule(static,1) default(none) \
 			shared(P, Hosts, Places, PropPlaces, Mcells, maxd, last_i, stderr_shared)
 		for (int tn = 0; tn < P.NumThreads; tn++)
-			for (j2 = P.nsp + tn; j2 < P.PlaceTypeNum; j2 += P.NumThreads)
+			for (j2 = P.school_types_count + tn; j2 < P.PlaceTypeNum; j2 += P.NumThreads)
 			{
 				t = 0;
 				P.PlaceTypeMaxAgeRead[j2] = 0;
@@ -1931,7 +1931,7 @@ void AssignPeopleToPlaces()
 					PeopleArray[index2] = tmp;
 				}
 				m = 0;
-				if (tp < P.nsp)
+				if (tp < P.school_types_count)
 				{
 					for (int i = 0; i < P.Nplace[tp]; i++)
 					{
@@ -1971,7 +1971,7 @@ void AssignPeopleToPlaces()
 						Places[tp][i].n = 0;
 					}
 				}
-				if (tp < P.nsp)
+				if (tp < P.school_types_count)
 				{
 					t = ((double)m) / ((double)P.Nplace[tp]);
 					fprintf(stderr, "Adjusting place weights by cell (Capacity=%i Demand=%i  Av place size=%lg)\n", m, cnt, t);
@@ -2050,7 +2050,7 @@ void AssignPeopleToPlaces()
 					s = ((double)Places[tp][i].treat_end_time) * 43 / 40 - 1;
 					m += (int)(Places[tp][i].treat_end_time = (unsigned short)(1.0 + ignpoi(s)));
 				}
-				if (tp < P.nsp)
+				if (tp < P.school_types_count)
 					s = ((double)cnt) * 1.075;
 				else
 					s = ((double)cnt) * 1.125;
@@ -2138,7 +2138,7 @@ void AssignPeopleToPlaces()
 											t = dist2_raw(Households[Hosts[i].hh].loc_x, Households[Hosts[i].hh].loc_y,
 												Places[tp][Mcells[ic].places[tp][cnt]].loc_x, Places[tp][Mcells[ic].places[tp][cnt]].loc_y);
 											s = numKernel(t);
-											if (tp < P.nsp)
+											if (tp < P.school_types_count)
 											{
 												t = ((double)Places[tp][Mcells[ic].places[tp][cnt]].treat_end_time);
 												if (HOST_AGE_YEAR(i) < P.PlaceTypeMaxAgeRead[tp])
@@ -2211,7 +2211,7 @@ void AssignPeopleToPlaces()
 									{
 										Hosts[i].PlaceLinks[tp] = NearestPlaces[tn][i2];
 										ca++;
-										if (tp < P.nsp)
+										if (tp < P.school_types_count)
 											Places[tp][Hosts[i].PlaceLinks[tp]].treat_end_time--;
 									}
 									if (!f) Hosts[i].PlaceLinks[tp] = -1;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -134,7 +134,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 						if (y >= P.SpatialBoundingBox[3]) P.SpatialBoundingBox[3] = y + 1e-6;
 					}
 			}
-			if (!P.DoSpecifyPop) P.PopSize = (int)s2;
+			if (!P.DoSpecifyPop) P.population_size = (int)s2;
 		}
 
 		P.in_cells_.height_ = P.in_cells_.width_;
@@ -153,7 +153,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.NC = P.ncw * P.nch;
 		fprintf(stderr, "Adjusted bounding box = (%lg, %lg)- (%lg, %lg)\n", P.SpatialBoundingBox[0], P.SpatialBoundingBox[1], P.SpatialBoundingBox[2], P.SpatialBoundingBox[3]);
 		fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.NC, P.ncw, P.nch);
-		fprintf(stderr, "Population size = %i \n", P.PopSize);
+		fprintf(stderr, "Population size = %i \n", P.population_size);
 		if (P.in_degrees_.width_ > 180) {
 			fprintf(stderr, "WARNING: Width of bounding box > 180 degrees.  Results may be inaccurate.\n");
 		}
@@ -168,11 +168,11 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.ncw = P.nch = (int)sqrt((double)P.NC);
 		P.NC = P.ncw * P.nch;
 		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.NC, P.ncw);
-		s = floor(sqrt((double)P.PopSize));
+		s = floor(sqrt((double)P.population_size));
 		P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 0;
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = s;
-		P.PopSize = (int)(s * s);
-		fprintf(stderr, "Population size adjusted to be %i (%lg^2)\n", P.PopSize, s);
+		P.population_size = (int)(s * s);
+		fprintf(stderr, "Population size adjusted to be %i (%lg^2)\n", P.population_size, s);
 		P.in_degrees_.width_ = P.in_degrees_.height_ = s;
 		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
 		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);
@@ -318,7 +318,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		Cells[i].L = Cells[i].I = Cells[i].R = 0;
 		//Cells[i].susceptible=Cells[i].members; //added this line
 	}
-	for (int i = 0; i < P.PopSize; i++) Hosts[i].keyworker = 0;
+	for (int i = 0; i < P.population_size; i++) Hosts[i].keyworker = 0;
 	P.KeyWorkerNum = P.KeyWorkerIncHouseNum = m = l = 0;
 
 	fprintf(stderr, "Initialising kernel...\n");
@@ -333,7 +333,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	{
 		while ((m < P.KeyWorkerPopNum) && (l < 1000))
 		{
-			int i = (int)(((double)P.PopSize) * ranf_mt(0));
+			int i = (int)(((double)P.population_size) * ranf_mt(0));
 			if (Hosts[i].keyworker)
 				l++;
 			else
@@ -365,7 +365,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 				for (int i2 = 0; (m < P.KeyWorkerPlaceNum[j]) && (i2 < Places[j][k].n); i2++)
 				{
 					int i = Places[j][k].members[i2];
-					if ((i < 0) || (i >= P.PopSize)) fprintf(stderr, "## %i # ", i);
+					if ((i < 0) || (i >= P.population_size)) fprintf(stderr, "## %i # ", i);
 					if ((Hosts[i].keyworker) || (ranf_mt(0) >= P.KeyWorkerPropInKeyPlaces[j]))
 						l++;
 					else
@@ -444,7 +444,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			P.NDigitalContactUsers = l;
 			P.NDigitalHouseholdUsers = m;
 			fprintf(stderr, "Number of digital contact tracing households: %i, out of total number of households: %i\n", P.NDigitalHouseholdUsers, P.NH);
-			fprintf(stderr, "Number of digital contact tracing users: %i, out of population size: %i\n", P.NDigitalContactUsers, P.PopSize);
+			fprintf(stderr, "Number of digital contact tracing users: %i, out of population size: %i\n", P.NDigitalContactUsers, P.population_size);
 		}
 		else // Just go through the population and assign people to the digital contact tracing app based on probability by age.
 		{
@@ -454,7 +454,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 				shared(P, Hosts)
 			for (int tn = 0; tn < P.NumThreads; tn++)
 			{
-				for (int i = tn; i < P.PopSize; i += P.NumThreads)
+				for (int i = tn; i < P.population_size; i += P.NumThreads)
 				{
 					int age = HOST_AGE_GROUP(i);
 					if (age >= NUM_AGE_GROUPS) age = NUM_AGE_GROUPS - 1;
@@ -467,7 +467,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 				}
 			}
 			P.NDigitalContactUsers = l;
-			fprintf(stderr, "Number of digital contact tracing users: %i, out of population size: %i\n", P.NDigitalContactUsers, P.PopSize);
+			fprintf(stderr, "Number of digital contact tracing users: %i, out of population size: %i\n", P.NDigitalContactUsers, P.population_size);
 		}
 	}
 
@@ -494,7 +494,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		shared(P, Households, Hosts)
 	for (int tn = 0; tn < P.NumThreads; tn++)
 	{
-		for (int i = tn; i < P.PopSize; i += P.NumThreads)
+		for (int i = tn; i < P.population_size; i += P.NumThreads)
 		{
 			if (P.SusceptibilitySD == 0)
 				Hosts[i].susc = (float)((P.DoPartialImmunity) ? (1.0 - P.InitialImmunity[HOST_AGE_GROUP(i)]) : 1.0);
@@ -534,8 +534,8 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			for (; k < l; k++) t2 += s2 * P.infectiousness[k];
 		}
 	}
-	t2 *= (s3 / ((double)P.PopSize));
-	s /= ((double)P.PopSize);
+	t2 *= (s3 / ((double)P.population_size));
+	s /= ((double)P.population_size);
 	fprintf(stderr, "Household mean size=%lg\nHousehold R0=%lg\n", t, P.R0household = s);
 	t = 0;
 	if (P.DoPlaces)
@@ -544,7 +544,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			{
 #pragma omp parallel for private(d,q,s2,s3,t3,l,m) schedule(static,1000) reduction(+:t) default(none) \
 					shared(P, Hosts, Places, j)
-				for (int i = 0; i < P.PopSize; i++)
+				for (int i = 0; i < P.population_size; i++)
 				{
 					int k = Hosts[i].PlaceLinks[j];
 					if (k >= 0)
@@ -581,22 +581,22 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 						t += (1 - t3 * d) * s3 + (1 - d) * (((double)(Places[j][k].n - 1)) - s3);
 					}
 				}
-				fprintf(stderr, "%lg  ", t / ((double)P.PopSize));
+				fprintf(stderr, "%lg  ", t / ((double)P.population_size));
 			}
 	{
 		double recovery_time_days = 0;
 		double recovery_time_timesteps = 0;
 #pragma omp parallel for schedule(static,500) reduction(+:recovery_time_days,recovery_time_timesteps) default(none) \
 			shared(P, Hosts)
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			recovery_time_days += Hosts[i].recovery_or_death_time * P.TimeStep;
 			recovery_time_timesteps += Hosts[i].recovery_or_death_time;
 			Hosts[i].recovery_or_death_time = 0;
 		}
-		t /= ((double)P.PopSize);
-		recovery_time_days /= ((double)P.PopSize);
-		recovery_time_timesteps /= ((double)P.PopSize);
+		t /= ((double)P.population_size);
+		recovery_time_days /= ((double)P.population_size);
+		recovery_time_timesteps /= ((double)P.population_size);
 		fprintf(stderr, "R0 for places = %lg\nR0 for random spatial = %lg\nOverall R0=%lg\n", P.R0places = t, P.R0spatial = P.R0 - s - t, P.R0);
 		fprintf(stderr, "Mean infectious period (sampled) = %lg (%lg)\n", recovery_time_days, recovery_time_timesteps);
 	}
@@ -623,7 +623,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	DoInitUpdateProbs = 1;
 	for (int i = 0; i < P.NC; i++)	Cells[i].tot_treat = 1;  //This makes sure InitModel intialises the cells.
 	P.NRactE = P.NRactNE = 0;
-	for (int i = 0; i < P.PopSize; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
+	for (int i = 0; i < P.population_size; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
 	if (P.EnhancedSocDistClusterByHousehold)
 	{
 		for (int i = 0; i < P.NH;i++)
@@ -643,9 +643,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	}
 	if (P.DoMassVacc)
 	{
-		if (!(State.mvacc_queue = (int*)calloc(P.PopSize, sizeof(int)))) ERR_CRITICAL("Unable to allocate host storage\n");
+		if (!(State.mvacc_queue = (int*)calloc(P.population_size, sizeof(int)))) ERR_CRITICAL("Unable to allocate host storage\n");
 		int queueIndex = 0;
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			if ((HOST_AGE_YEAR(i) >= P.VaccPriorityGroupAge[0]) && (HOST_AGE_YEAR(i) <= P.VaccPriorityGroupAge[1]))
 			{
@@ -654,7 +654,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			}
 		}
 		int vaccineCount = queueIndex;
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			if ((HOST_AGE_YEAR(i) < P.VaccPriorityGroupAge[0]) || (HOST_AGE_YEAR(i) > P.VaccPriorityGroupAge[1]))
 			{
@@ -993,16 +993,16 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		t = 0;
 		for (int i = 0; i < P.NumAdunits; i++)
 			t += P.PopByAdunit[i][1];
-		int i = P.PopSize;
-		P.PopSize = (int)t;
-		fprintf(stderr, "Population size reset from %i to %i\n", i, P.PopSize);
+		int i = P.population_size;
+		P.population_size = (int)t;
+		fprintf(stderr, "Population size reset from %i to %i\n", i, P.population_size);
 	}
 	t = 1.0;
 	for (int i = m = 0; i < (P.NMC - 1); i++)
 	{
 		s = mcell_dens[i] / maxd / t;
 		if (s > 1.0) s = 1.0;
-		m += (Mcells[i].n = (int)ignbin_mt((int32_t)(P.PopSize - m), s, 0));
+		m += (Mcells[i].n = (int)ignbin_mt((int32_t)(P.population_size - m), s, 0));
 		t -= mcell_dens[i] / maxd;
 		if (Mcells[i].n > 0) {
 			P.NMCP++;
@@ -1010,7 +1010,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			AdUnits[mcell_adunits[i]].n += Mcells[i].n;
 		}
 	}
-	Mcells[P.NMC - 1].n = P.PopSize - m;
+	Mcells[P.NMC - 1].n = P.population_size - m;
 	if (Mcells[P.NMC - 1].n > 0)
 	{
 		P.NMCP++;
@@ -1024,7 +1024,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	t = 0.0;
 
 	if (!(McellLookup = (Microcell * *)malloc(P.NMCP * sizeof(Microcell*)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
-	if (!(State.CellMemberArray = (int*)malloc(P.PopSize * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+	if (!(State.CellMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	P.NCP = 0;
 	for (int i = i2 = j2 = 0; i < P.NC; i++)
 	{
@@ -1052,7 +1052,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	fprintf(stderr, "Number of microcells with non-zero population = %i\n", P.NMCP);
 
 	if (!(CellLookup = (Cell * *)malloc(P.NCP * sizeof(Cell*)))) ERR_CRITICAL("Unable to allocate cell storage\n");
-	if (!(State.CellSuscMemberArray = (int*)malloc(P.PopSize * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+	if (!(State.CellSuscMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	int susceptibleAccumulator = 0;
 	i2 = 0;
 	for (j = 0; j < P.NC; j++)
@@ -1065,7 +1065,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	if (i2 > P.NCP) fprintf(stderr, "######## Over-run on CellLookup array NCP=%i i2=%i ###########\n", P.NCP, i2);
 	i2 = 0;
 
-	if (!(Hosts = (Person*)calloc(P.PopSize, sizeof(Person)))) ERR_CRITICAL("Unable to allocate host storage\n");
+	if (!(Hosts = (Person*)calloc(P.population_size, sizeof(Person)))) ERR_CRITICAL("Unable to allocate host storage\n");
 	fprintf(stderr, "sizeof(Person)=%i\n", (int) sizeof(Person));
 	for (int i = 0; i < P.NCP; i++)
 	{
@@ -1171,7 +1171,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		for (int i = 0; i < P.NumAdunits; i++)
 			for (j = 0; j < NUM_AGE_GROUPS; j++)
 				AgeDistAd[i][j] = 0;
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			int k = (P.DoAdunitDemog) ? Mcells[Hosts[i].mcell].adunit : 0;
 			AgeDistAd[k][HOST_AGE_GROUP(i)]++;
@@ -1218,7 +1218,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 #pragma omp parallel for private(j,k,m,s) schedule(static,1) default(none) \
 			shared(P, Hosts, AgeDistCorrF, AgeDistCorrB, Mcells)
 		for (int tn = 0; tn < P.NumThreads; tn++)
-			for (int i = tn; i < P.PopSize; i += P.NumThreads)
+			for (int i = tn; i < P.population_size; i += P.NumThreads)
 			{
 				m = (P.DoAdunitDemog) ? Mcells[Hosts[i].mcell].adunit : 0;
 				j = HOST_AGE_GROUP(i);
@@ -1239,7 +1239,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		free(AgeDistCorrF);
 		free(AgeDistCorrB);
 	}
-	for (int i = 0; i < P.PopSize; i++)
+	for (int i = 0; i < P.population_size; i++)
 	{
 		if (Hosts[i].age >= NUM_AGE_GROUPS * AGE_GROUP_WIDTH)
 		{
@@ -1279,7 +1279,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			ERR_CRITICAL("Too few people in seed microcell to start epidemic with required number of initial infectionz.\n");
 	}
 	fprintf(stderr, "Checking cells...\n");
-	maxd = ((double)P.PopSize);
+	maxd = ((double)P.population_size);
 	last_i = 0;
 	for (int i = 0; i < P.NMC; i++)
 		if (Mcells[i].n > 0) last_i = i;
@@ -1364,7 +1364,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		for (j = 0; j < P.nsp; j++)
 		{
 			t = s = 0;
-			for (int i = 0; i < P.PopSize; i++)
+			for (int i = 0; i < P.population_size; i++)
 				t += PropPlaces[HOST_AGE_YEAR(i)][j];
 			for (int i = 0; i < P.Nplace[j]; i++)
 			{
@@ -1390,7 +1390,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			{
 				t = 0;
 				P.PlaceTypeMaxAgeRead[j2] = 0;
-				for (int i = 0; i < P.PopSize; i++)
+				for (int i = 0; i < P.population_size; i++)
 					t += PropPlaces[HOST_AGE_YEAR(i)][j2];
 				P.Nplace[j2] = (int)ceil(t / P.PlaceTypeMeanSize[j2]);
 				fprintf(stderr_shared, "[%i:%i %g] ", j2, P.Nplace[j2], t);
@@ -1445,7 +1445,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	for (j = 0; j < P.NC; j++)
 		if (l < Cells[j].n) l = Cells[j].n;
 	if (!(SamplingQueue = (int**)malloc(P.NumThreads * sizeof(int*)))) ERR_CRITICAL("Unable to allocate state storage\n");
-	P.InfQueuePeakLength = P.PopSize / P.NumThreads / INF_QUEUE_SCALE;
+	P.InfQueuePeakLength = P.population_size / P.NumThreads / INF_QUEUE_SCALE;
 #pragma omp parallel for schedule(static,1) default(none) \
 		shared(P, SamplingQueue, StateT, l)
 	for (int i = 0; i < P.NumThreads; i++)
@@ -1876,7 +1876,7 @@ void AssignPeopleToPlaces()
 		}
 
 		//PropPlaces initialisation is only valid for non-overlapping places.
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 		{
 			for (tp = 0; tp < npt; tp++) //Changed from 'for(tp=0;tp<P.PlaceTypeNum;tp++)' to try and assign -1 early and avoid problems when using less than the default number of placetypes later
 			{
@@ -2331,7 +2331,7 @@ void StratifyPlaces(void)
 		fprintf(stderr, "Initialising groups in places\n");
 #pragma omp parallel for schedule(static,500) default(none) \
 			shared(P, Hosts)
-		for (int i = 0; i < P.PopSize; i++)
+		for (int i = 0; i < P.population_size; i++)
 			for (int j = 0; j < NUM_PLACE_TYPES; j++)
 				Hosts[i].PlaceGroupLinks[j] = 0;
 		for (int j = 0; j < P.PlaceTypeNum; j++)
@@ -2353,7 +2353,7 @@ void StratifyPlaces(void)
 				}
 				else
 				{
-					for (int i = 0; i < P.PopSize; i++)
+					for (int i = 0; i < P.population_size; i++)
 					{
 						if (Hosts[i].PlaceLinks[j] >= 0)
 							Places[j][Hosts[i].PlaceLinks[j]].n++;
@@ -2366,7 +2366,7 @@ void StratifyPlaces(void)
 						}
 						Places[j][i].n = 0;
 					}
-					for (int i = 0; i < P.PopSize; i++)
+					for (int i = 0; i < P.population_size; i++)
 					{
 						int k = Hosts[i].PlaceLinks[j];
 						if (k >= 0)
@@ -2450,11 +2450,11 @@ void StratifyPlaces(void)
 					fprintf(stderr,"Mean group size for place type %i = %lg\n",j,t/s);
 					}
 				t=0;
-				for(i=0;i<P.PopSize;i++)
+				for(i=0;i<P.population_size;i++)
 					for(j=0;j<P.PlaceTypeNum;j++)
 						if(Hosts[i].PlaceLinks[j]>=0)
 							t+=(double) Places[j][Hosts[i].PlaceLinks[j]].group_size[Hosts[i].PlaceGroupLinks[j]];
-				fprintf(stderr,"Overall mean group size = %lg (%lg)\n",t/((double) P.PopSize),t2/s2);
+				fprintf(stderr,"Overall mean group size = %lg (%lg)\n",t/((double) P.population_size),t2/s2);
 		*/
 	}
 }
@@ -2479,17 +2479,17 @@ void LoadPeopleToPlaces(char* NetworkFile)
 	fread_big(&s1, sizeof(int32_t), 1, dat);
 	fread_big(&s2, sizeof(int32_t), 1, dat);
 	if (i != npt) ERR_CRITICAL("Number of place types does not match saved value\n");
-	if (j != P.PopSize) ERR_CRITICAL("Population size does not match saved value\n");
+	if (j != P.population_size) ERR_CRITICAL("Population size does not match saved value\n");
 	if ((s1 != P.setupSeed1) || (s2 != P.setupSeed2)) {
     ERR_CRITICAL_FMT("Random number seeds do not match saved values: %" PRId32 " != %" PRId32 " || %" PRId32 " != %" PRId32 "\n", s1, P.setupSeed1, s2, P.setupSeed2);
   }
-	k = (P.PopSize + 999999) / 1000000;
-	for (i = 0; i < P.PopSize; i++)
+	k = (P.population_size + 999999) / 1000000;
+	for (i = 0; i < P.population_size; i++)
 		for (j = 0; j < P.PlaceTypeNum; j++)
 			Hosts[i].PlaceLinks[j] = -1;
 	for (i = i2 = 0; i < k; i++)
 	{
-		l = (i < k - 1) ? 1000000 : (P.PopSize - 1000000 * (k - 1));
+		l = (i < k - 1) ? 1000000 : (P.population_size - 1000000 * (k - 1));
 		fread_big(&netbuf, sizeof(int), npt * l, dat);
 		for (j = 0; j < l; j++)
 		{
@@ -2508,7 +2508,7 @@ void LoadPeopleToPlaces(char* NetworkFile)
 		fprintf(stderr, "%i loaded            \r", i * 1000000 + l);
 	}
 
-	/*	for(i=0;i<P.PopSize;i++)
+	/*	for(i=0;i<P.population_size;i++)
 			{
 			if((i+1)%100000==0) fprintf(stderr,"%i loaded            \r",i+1);
 			fread_big(&(Hosts[i].PlaceLinks[0]),sizeof(int),P.PlaceTypeNum,dat);
@@ -2529,10 +2529,10 @@ void SavePeopleToPlaces(char* NetworkFile)
 	if (P.PlaceTypeNum > 0)
 	{
 		fwrite_big(&npt, sizeof(int), 1, dat);
-		fwrite_big(&(P.PopSize), sizeof(int), 1, dat);
+		fwrite_big(&(P.population_size), sizeof(int), 1, dat);
 		fwrite_big(&P.setupSeed1, sizeof(int32_t), 1, dat);
 		fwrite_big(&P.setupSeed2, sizeof(int32_t), 1, dat);
-		for (i = 0; i < P.PopSize; i++)
+		for (i = 0; i < P.population_size; i++)
 		{
 			if ((i + 1) % 100000 == 0) fprintf(stderr, "%i saved            \r", i + 1);
 			/*			fwrite_big(&(Hosts[i].spatial_norm),sizeof(float),1,dat);

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -177,8 +177,8 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
 		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);
 	}
-	P.NMC = P.NMCL * P.NMCL * P.cells_count;
-	fprintf(stderr, "Number of microcells = %i\n", P.NMC);
+	P.microcells_count = P.NMCL * P.NMCL * P.cells_count;
+	fprintf(stderr, "Number of microcells = %i\n", P.microcells_count);
 	P.scalex = P.BitmapScale;
 	P.scaley = P.BitmapAspectScale * P.BitmapScale;
 	P.bwidth = (int)(P.in_degrees_.width_ * (P.BoundingBox[2] - P.BoundingBox[0]) * P.scalex);
@@ -713,13 +713,13 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	int *mcell_adunits, *mcell_num, *mcell_country;
 
 	if (!(Cells = (Cell*)calloc(P.cells_count, sizeof(Cell)))) ERR_CRITICAL("Unable to allocate cell storage\n");
-	if (!(Mcells = (Microcell*)calloc(P.NMC, sizeof(Microcell)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
-	if (!(mcell_num = (int*)malloc(P.NMC * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
-	if (!(mcell_dens = (double*)malloc(P.NMC * sizeof(double)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
-	if (!(mcell_country = (int*)malloc(P.NMC * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
-	if (!(mcell_adunits = (int*)malloc(P.NMC * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(Mcells = (Microcell*)calloc(P.microcells_count, sizeof(Microcell)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(mcell_num = (int*)malloc(P.microcells_count * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(mcell_dens = (double*)malloc(P.microcells_count * sizeof(double)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(mcell_country = (int*)malloc(P.microcells_count * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(mcell_adunits = (int*)malloc(P.microcells_count * sizeof(int)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 
-	for (j = 0; j < P.NMC; j++)
+	for (j = 0; j < P.microcells_count; j++)
 	{
 		Mcells[j].n = 0;
 		mcell_adunits[j] = -1;
@@ -783,7 +783,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 				j = (int)floor((x - P.SpatialBoundingBox[0]) / P.in_microcells_.width_ + 0.1);
 				k = (int)floor((y - P.SpatialBoundingBox[1]) / P.in_microcells_.height_ + 0.1);
 				l = j * P.get_number_of_micro_cells_high() + k;
-				if (l < P.NMC)
+				if (l < P.microcells_count)
 				{
 					mr++;
 					mcell_dens[l] += t;
@@ -816,13 +816,13 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 				free(BinFileBuf);
 				P.DoBin = 1;
 				P.binary_file_lines_count = 0;
-				for (l = 0; l < P.NMC; l++)
+				for (l = 0; l < P.microcells_count; l++)
 					if (mcell_adunits[l] >= 0) P.binary_file_lines_count++;
 				if (!(BinFileBuf = (void*)malloc(P.binary_file_lines_count * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
 				BF = (BinFile*)BinFileBuf;
 				fprintf(stderr, "Binary density file should contain %i microcells.\n", (int)P.binary_file_lines_count);
 				rn = 0;
-				for (l = 0; l < P.NMC; l++)
+				for (l = 0; l < P.microcells_count; l++)
 					if (mcell_adunits[l] >= 0)
 					{
 						BF[rn].x = (double)(P.in_microcells_.width_ * (((double)(l / P.get_number_of_micro_cells_high())) + 0.5)) + P.SpatialBoundingBox[0]; //x
@@ -848,7 +848,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		free(BinFileBuf);
 		fprintf(stderr, "Population files read.\n");
 		maxd = 0;
-		for (int i = 0; i < P.NMC; i++)
+		for (int i = 0; i < P.microcells_count; i++)
 		{
 			if (mcell_num[i] > 0)
 			{
@@ -866,12 +866,12 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	}
 	else
 	{
-		for (int i = 0; i < P.NMC; i++)
+		for (int i = 0; i < P.microcells_count; i++)
 		{
 			mcell_dens[i] = 1.0;
 			Mcells[i].country = 1;
 		}
-		maxd = ((double)P.NMC);
+		maxd = ((double)P.microcells_count);
 	}
 	if (!P.DoAdUnits) P.NumAdunits = 1;
 	if ((P.DoAdUnits) && (P.DoAdunitDemog))
@@ -981,7 +981,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		for (int i = 0; i < P.NumAdunits; i++)
 			fprintf(stderr, "%i\t%i\t%lg\t%lg\n", i, (AdUnits[i].id % P.AdunitLevel1Mask) / P.AdunitLevel1Divisor, P.PropAgeGroup[i][0], P.HouseholdSizeDistrib[i][0]);
 		maxd = 0;
-		for (int i = 0; i < P.NMC; i++)
+		for (int i = 0; i < P.microcells_count; i++)
 		{
 			if (mcell_num[i] > 0)
             {
@@ -998,7 +998,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		fprintf(stderr, "Population size reset from %i to %i\n", i, P.population_size);
 	}
 	t = 1.0;
-	for (int i = m = 0; i < (P.NMC - 1); i++)
+	for (int i = m = 0; i < (P.microcells_count - 1); i++)
 	{
 		s = mcell_dens[i] / maxd / t;
 		if (s > 1.0) s = 1.0;
@@ -1010,11 +1010,11 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			AdUnits[mcell_adunits[i]].n += Mcells[i].n;
 		}
 	}
-	Mcells[P.NMC - 1].n = P.population_size - m;
-	if (Mcells[P.NMC - 1].n > 0)
+	Mcells[P.microcells_count - 1].n = P.population_size - m;
+	if (Mcells[P.microcells_count - 1].n > 0)
 	{
 		P.NMCP++;
-		AdUnits[mcell_adunits[P.NMC - 1]].n += Mcells[P.NMC - 1].n;
+		AdUnits[mcell_adunits[P.microcells_count - 1]].n += Mcells[P.microcells_count - 1].n;
 	}
 
 	free(mcell_dens);
@@ -1281,7 +1281,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	fprintf(stderr, "Checking cells...\n");
 	maxd = ((double)P.population_size);
 	last_i = 0;
-	for (int i = 0; i < P.NMC; i++)
+	for (int i = 0; i < P.microcells_count; i++)
 		if (Mcells[i].n > 0) last_i = i;
 	fprintf(stderr, "Allocating place/age groups...\n");
 	for (int k = 0; k < NUM_AGE_GROUPS * AGE_GROUP_WIDTH; k++)
@@ -1329,7 +1329,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			for (int i = 0; i < m; i++)
 				if (!(Places[j][i].AvailByAge = (unsigned short int*) malloc(P.PlaceTypeMaxAgeRead[j] * sizeof(unsigned short int)))) ERR_CRITICAL("Unable to allocate place storage\n");
 			P.Nplace[j] = 0;
-			for (int i = 0; i < P.NMC; i++) Mcells[i].np[j] = 0;
+			for (int i = 0; i < P.microcells_count; i++) Mcells[i].np[j] = 0;
 		}
 		mr = 0;
 		while (!feof(dat))
@@ -1354,7 +1354,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		}
 		fclose(dat);
 		fprintf(stderr, "%i schools read (%i in empty cells)      \n", P.Nplace[j], mr);
-		for (int i = 0; i < P.NMC; i++)
+		for (int i = 0; i < P.microcells_count; i++)
 			for (j = 0; j < P.nsp; j++)
 				if (Mcells[i].np[j] > 0)
 				{
@@ -1397,7 +1397,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 				if (!(Places[j2] = (Place*)calloc(P.Nplace[j2], sizeof(Place)))) ERR_CRITICAL("Unable to allocate place storage\n");
 				t = 1.0;
 				int k;
-				for (int i = m = k = 0; i < P.NMC; i++)
+				for (int i = m = k = 0; i < P.microcells_count; i++)
 				{
 					s = ((double) Mcells[i].n) / maxd / t;
 					if (s > 1.0) s = 1.0;
@@ -1436,7 +1436,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 						PropPlaces[k][l] = 1.0;
 				}
 /*		for (j2 = 0; j2 < P.PlaceTypeNum; j2++)
-			for (i =0; i < P.NMC; i++)
+			for (i =0; i < P.microcells_count; i++)
 				if ((Mcells[i].np[j2]>0) && (Mcells[i].n == 0))
 					fprintf(stderr, "\n##~ %i %i %i \n", i, j2, Mcells[i].np[j2]);
 */		fprintf(stderr, "Places assigned\n");
@@ -1521,7 +1521,7 @@ void SetupAirports(void)
 	if (!(base = (IndexList*)calloc(P.NMCP * NNA, sizeof(IndexList)))) ERR_CRITICAL("Unable to allocate airport storage\n");
 	for (int i = 0; i < P.Nairports; i++) Airports[i].num_mcell = 0;
 	cur = base;
-	for (int i = 0; i < P.NMC; i++)
+	for (int i = 0; i < P.microcells_count; i++)
 		if (Mcells[i].n > 0)
 		{
 			Mcells[i].AirportList = cur;
@@ -1531,7 +1531,7 @@ void SetupAirports(void)
 	FILE* stderr_shared = stderr;
 #pragma omp parallel for private(k,l,x,y,t,tmin) schedule(static,10000) default(none) \
 		shared(P, Airports, Mcells, stderr_shared)
-	for (int i = 0; i < P.NMC; i++)
+	for (int i = 0; i < P.microcells_count; i++)
 		if (Mcells[i].n > 0)
 		{
 			if (i % 10000 == 0) fprintf(stderr_shared, "\n%i           ", i);
@@ -1576,7 +1576,7 @@ void SetupAirports(void)
 	}
 #pragma omp parallel for private(k,l,t,tmin) schedule(static,10000) default(none) \
 		shared(P, Airports, Mcells, stderr_shared)
-	for (int i = 0; i < P.NMC; i++)
+	for (int i = 0; i < P.microcells_count; i++)
 		if (Mcells[i].n > 0)
 		{
 			if (i % 10000 == 0) fprintf(stderr_shared, "\n%i           ", i);

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -177,7 +177,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
 		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);
 	}
-	P.microcells_count = P.NMCL * P.NMCL * P.cells_count;
+	P.microcells_count = P.cell_length_microcells * P.cell_length_microcells * P.cells_count;
 	fprintf(stderr, "Number of microcells = %i\n", P.microcells_count);
 	P.scalex = P.BitmapScale;
 	P.scaley = P.BitmapAspectScale * P.BitmapScale;
@@ -190,8 +190,8 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	fprintf(stderr, "Bitmap width = %i\nBitmap height = %i\n", P.bwidth, P.bheight);
 	P.bminx = (int)(P.in_degrees_.width_ * P.BoundingBox[0] * P.scalex);
 	P.bminy = (int)(P.in_degrees_.height_ * P.BoundingBox[1] * P.scaley);
-	P.in_microcells_.width_ = P.in_cells_.width_ / ((double)P.NMCL);
-	P.in_microcells_.height_ = P.in_cells_.height_ / ((double)P.NMCL);
+	P.in_microcells_.width_ = P.in_cells_.width_ / ((double)P.cell_length_microcells);
+	P.in_microcells_.height_ = P.in_cells_.height_ / ((double)P.cell_length_microcells);
 	for (int i = 0; i < P.NumSeedLocations; i++)
 	{
 		P.LocationInitialInfection[i][0] -= P.SpatialBoundingBox[0];
@@ -1029,10 +1029,10 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	for (int i = i2 = j2 = 0; i < P.cells_count; i++)
 	{
 		Cells[i].n = 0;
-		int k = (i / P.nch) * P.NMCL * P.get_number_of_micro_cells_high() + (i % P.nch) * P.NMCL;
+		int k = (i / P.nch) * P.cell_length_microcells * P.get_number_of_micro_cells_high() + (i % P.nch) * P.cell_length_microcells;
 		Cells[i].members = State.CellMemberArray + j2;
-		for (l = 0; l < P.NMCL; l++)
-			for (m = 0; m < P.NMCL; m++)
+		for (l = 0; l < P.cell_length_microcells; l++)
+			for (m = 0; m < P.cell_length_microcells; m++)
 			{
 				j = k + m + l * P.get_number_of_micro_cells_high();
 				if (Mcells[j].n > 0)
@@ -1089,7 +1089,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	for (j2 = 0; j2 < P.NMCP; j2++)
 	{
 		j = (int)(McellLookup[j2] - Mcells);
-		l = ((j / P.get_number_of_micro_cells_high()) / P.NMCL) * P.nch + ((j % P.get_number_of_micro_cells_high()) / P.NMCL);
+		l = ((j / P.get_number_of_micro_cells_high()) / P.cell_length_microcells) * P.nch + ((j % P.get_number_of_micro_cells_high()) / P.cell_length_microcells);
 		ad = ((P.DoAdunitDemog) && (P.DoAdUnits)) ? Mcells[j].adunit : 0;
 		for (int k = 0; k < Mcells[j].n;)
 		{

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1025,7 +1025,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 
 	if (!(McellLookup = (Microcell * *)malloc(P.NMCP * sizeof(Microcell*)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 	if (!(State.CellMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
-	P.NCP = 0;
+	P.populated_cells_count = 0;
 	for (int i = i2 = j2 = 0; i < P.cells_count; i++)
 	{
 		Cells[i].n = 0;
@@ -1044,14 +1044,14 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 					j2 += Mcells[j].n;
 				}
 			}
-		if (Cells[i].n > 0) P.NCP++;
+		if (Cells[i].n > 0) P.populated_cells_count++;
 	}
 	fprintf(stderr, "Number of hosts assigned = %i\n", j2);
 	if (!P.DoAdUnits) P.AdunitLevel1Lookup[0] = 0;
-	fprintf(stderr, "Number of cells with non-zero population = %i\n", P.NCP);
+	fprintf(stderr, "Number of cells with non-zero population = %i\n", P.populated_cells_count);
 	fprintf(stderr, "Number of microcells with non-zero population = %i\n", P.NMCP);
 
-	if (!(CellLookup = (Cell * *)malloc(P.NCP * sizeof(Cell*)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+	if (!(CellLookup = (Cell * *)malloc(P.populated_cells_count * sizeof(Cell*)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	if (!(State.CellSuscMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	int susceptibleAccumulator = 0;
 	i2 = 0;
@@ -1062,19 +1062,19 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			Cells[j].susceptible = State.CellSuscMemberArray + susceptibleAccumulator;
 			susceptibleAccumulator += Cells[j].n;
 		}
-	if (i2 > P.NCP) fprintf(stderr, "######## Over-run on CellLookup array NCP=%i i2=%i ###########\n", P.NCP, i2);
+	if (i2 > P.populated_cells_count) fprintf(stderr, "######## Over-run on CellLookup array NCP=%i i2=%i ###########\n", P.populated_cells_count, i2);
 	i2 = 0;
 
 	if (!(Hosts = (Person*)calloc(P.population_size, sizeof(Person)))) ERR_CRITICAL("Unable to allocate host storage\n");
 	fprintf(stderr, "sizeof(Person)=%i\n", (int) sizeof(Person));
-	for (int i = 0; i < P.NCP; i++)
+	for (int i = 0; i < P.populated_cells_count; i++)
 	{
 		Cell *c = CellLookup[i];
 		if (c->n > 0)
 		{
 			if (!(c->InvCDF = (int*)malloc(1025 * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
-			if (!(c->max_trans = (float*)malloc(P.NCP * sizeof(float)))) ERR_CRITICAL("Unable to allocate cell storage\n");
-			if (!(c->cum_trans = (float*)malloc(P.NCP * sizeof(float)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+			if (!(c->max_trans = (float*)malloc(P.populated_cells_count * sizeof(float)))) ERR_CRITICAL("Unable to allocate cell storage\n");
+			if (!(c->cum_trans = (float*)malloc(P.populated_cells_count * sizeof(float)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 		}
 	}
 	for (int i = 0; i < P.cells_count; i++)
@@ -1889,7 +1889,7 @@ void AssignPeopleToPlaces()
 			if (tp != P.HotelPlaceType)
 			{
 				cnt = 0;
-				for (a = 0; a < P.NCP; a++)
+				for (a = 0; a < P.populated_cells_count; a++)
 				{
 					Cell *c = CellLookup[a];
 					c->n = 0;
@@ -1913,7 +1913,7 @@ void AssignPeopleToPlaces()
 				}
 				if (!(PeopleArray = (int*)calloc(cnt, sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 				j2 = 0;
-				for (a = 0; a < P.NCP; a++)
+				for (a = 0; a < P.populated_cells_count; a++)
 				{
 					Cell *c = CellLookup[a];
 					for (j = 0; j < c->n; j++)

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1154,7 +1154,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 				k += m;
 			}
 		}
-	if (P.DoCorrectAgeDist)
+	if (P.should_correct_age_distributions)
 	{
 		double** AgeDistAd, ** AgeDistCorrF, ** AgeDistCorrB;
 		if (!(AgeDistAd = (double**)malloc(MAX_ADUNITS * sizeof(double*)))) ERR_CRITICAL("Unable to allocate temp storage\n");

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1005,7 +1005,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		m += (Mcells[i].n = (int)ignbin_mt((int32_t)(P.population_size - m), s, 0));
 		t -= mcell_dens[i] / maxd;
 		if (Mcells[i].n > 0) {
-			P.NMCP++;
+			P.populated_microcells_count++;
 			if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
 			AdUnits[mcell_adunits[i]].n += Mcells[i].n;
 		}
@@ -1013,7 +1013,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	Mcells[P.microcells_count - 1].n = P.population_size - m;
 	if (Mcells[P.microcells_count - 1].n > 0)
 	{
-		P.NMCP++;
+		P.populated_microcells_count++;
 		AdUnits[mcell_adunits[P.microcells_count - 1]].n += Mcells[P.microcells_count - 1].n;
 	}
 
@@ -1023,7 +1023,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	free(mcell_adunits);
 	t = 0.0;
 
-	if (!(McellLookup = (Microcell * *)malloc(P.NMCP * sizeof(Microcell*)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
+	if (!(McellLookup = (Microcell * *)malloc(P.populated_microcells_count * sizeof(Microcell*)))) ERR_CRITICAL("Unable to allocate microcell storage\n");
 	if (!(State.CellMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	P.populated_cells_count = 0;
 	for (int i = i2 = j2 = 0; i < P.cells_count; i++)
@@ -1049,7 +1049,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	fprintf(stderr, "Number of hosts assigned = %i\n", j2);
 	if (!P.DoAdUnits) P.AdunitLevel1Lookup[0] = 0;
 	fprintf(stderr, "Number of cells with non-zero population = %i\n", P.populated_cells_count);
-	fprintf(stderr, "Number of microcells with non-zero population = %i\n", P.NMCP);
+	fprintf(stderr, "Number of microcells with non-zero population = %i\n", P.populated_microcells_count);
 
 	if (!(CellLookup = (Cell * *)malloc(P.populated_cells_count * sizeof(Cell*)))) ERR_CRITICAL("Unable to allocate cell storage\n");
 	if (!(State.CellSuscMemberArray = (int*)malloc(P.population_size * sizeof(int)))) ERR_CRITICAL("Unable to allocate cell storage\n");
@@ -1086,7 +1086,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	for (int i = 0; i <= MAX_HOUSEHOLD_SIZE; i++) denom_household[i] = 0;
 	P.households_count = 0;
 	int numberOfPeople = 0;
-	for (j2 = 0; j2 < P.NMCP; j2++)
+	for (j2 = 0; j2 < P.populated_microcells_count; j2++)
 	{
 		j = (int)(McellLookup[j2] - Mcells);
 		l = ((j / P.get_number_of_micro_cells_high()) / P.cell_length_microcells) * P.nch + ((j % P.get_number_of_micro_cells_high()) / P.cell_length_microcells);
@@ -1124,7 +1124,7 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 #pragma omp parallel for private(j2,j,x,y,xh,yh,i2,m) schedule(static,1) default(none) \
 		shared(P, Households, Hosts, Mcells, McellLookup, AdUnits, stderr_shared)
 	for (int tn = 0; tn < P.NumThreads; tn++)
-		for (j2 = tn; j2 < P.NMCP; j2 += P.NumThreads)
+		for (j2 = tn; j2 < P.populated_microcells_count; j2 += P.NumThreads)
 		{
 			j = (int)(McellLookup[j2] - Mcells);
 			x = (double)(j / P.get_number_of_micro_cells_high());
@@ -1517,8 +1517,8 @@ void SetupAirports(void)
 	P.KernelP3 = P.AirportKernelP3;
 	P.KernelP4 = P.AirportKernelP4;
 	InitKernel(1.0);
-	if (!(Airports[0].DestMcells = (IndexList*)calloc(P.NMCP * NNA, sizeof(IndexList)))) ERR_CRITICAL("Unable to allocate airport storage\n");
-	if (!(base = (IndexList*)calloc(P.NMCP * NNA, sizeof(IndexList)))) ERR_CRITICAL("Unable to allocate airport storage\n");
+	if (!(Airports[0].DestMcells = (IndexList*)calloc(P.populated_microcells_count * NNA, sizeof(IndexList)))) ERR_CRITICAL("Unable to allocate airport storage\n");
+	if (!(base = (IndexList*)calloc(P.populated_microcells_count * NNA, sizeof(IndexList)))) ERR_CRITICAL("Unable to allocate airport storage\n");
 	for (int i = 0; i < P.Nairports; i++) Airports[i].num_mcell = 0;
 	cur = base;
 	for (int i = 0; i < P.microcells_count; i++)

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -622,7 +622,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			inf_household_av[i][j] = case_household_av[i][j] = 0;
 	DoInitUpdateProbs = 1;
 	for (int i = 0; i < P.cells_count; i++) Cells[i].tot_treat = 1;  //This makes sure InitModel intialises the cells.
-	P.actual_extinct_realisations_count = P.NRactNE = 0;
+	P.actual_extinct_realisations_count = P.actual_non_extinct_realisations_count = 0;
 	for (int i = 0; i < P.population_size; i++) Hosts[i].esocdist_comply = (ranf() < P.EnhancedSocDistProportionCompliant[HOST_AGE_GROUP(i)]) ? 1 : 0;
 	if (P.EnhancedSocDistClusterByHousehold)
 	{

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -46,9 +46,9 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		if (density_file_header == 0xf0f0f0f0) //code for first 4 bytes of binary file ## NOTE - SHOULD BE LONG LONG TO COPE WITH BIGGER POPULATIONS
 		{
 			P.DoBin = 1;
-			fread_big(&(P.BinFileLen), sizeof(unsigned int), 1, dat);
-			if (!(BinFileBuf = (void*)malloc(P.BinFileLen * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
-			fread_big(BinFileBuf, sizeof(BinFile), (size_t)P.BinFileLen, dat);
+			fread_big(&(P.binary_file_size), sizeof(unsigned int), 1, dat);
+			if (!(BinFileBuf = (void*)malloc(P.binary_file_size * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
+			fread_big(BinFileBuf, sizeof(BinFile), (size_t)P.binary_file_size, dat);
 			BF = (BinFile*)BinFileBuf;
 			fclose(dat);
 		}
@@ -57,12 +57,12 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			P.DoBin = 0;
 			// Count the number of lines in the density file
 			rewind(dat);
-			P.BinFileLen = 0;
-			while(fgets(buf, sizeof(buf), dat) != NULL) P.BinFileLen++;
+			P.binary_file_size = 0;
+			while(fgets(buf, sizeof(buf), dat) != NULL) P.binary_file_size++;
 			if(ferror(dat)) ERR_CRITICAL("Error while reading density file\n");
 			// Read each line, and build the binary structure that corresponds to it
 			rewind(dat);
-			if (!(BinFileBuf = (void*)malloc(P.BinFileLen * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
+			if (!(BinFileBuf = (void*)malloc(P.binary_file_size * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
 			BF = (BinFile*)BinFileBuf;
 			int index = 0;
 			while(fgets(buf, sizeof(buf), dat) != NULL)
@@ -70,7 +70,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 				int i2;
 				double x, y;
 				// This shouldn't be able to happen, as we just counted the number of lines:
-				if (index == P.BinFileLen) ERR_CRITICAL("Too many input lines while reading density file\n");
+				if (index == P.binary_file_size) ERR_CRITICAL("Too many input lines while reading density file\n");
 				if (P.DoAdUnits)
 				{
 					sscanf(buf, "%lg %lg %lg %i %i", &x, &y, &t, &i2, &l);
@@ -99,7 +99,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			}
 			if(ferror(dat)) ERR_CRITICAL("Error while reading density file\n");
 			// This shouldn't be able to happen, as we just counted the number of lines:
-			if (index != P.BinFileLen) ERR_CRITICAL("Too few input lines while reading density file\n");
+			if (index != P.binary_file_size) ERR_CRITICAL("Too few input lines while reading density file\n");
 			fclose(dat);
 		}
 
@@ -111,7 +111,7 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 1e10;
 			P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = -1e10;
 			s2 = 0;
-			for (rn = 0; rn < P.BinFileLen; rn++)
+			for (rn = 0; rn < P.binary_file_size; rn++)
 			{
 				double x = BF[rn].x;
 				double y = BF[rn].y;
@@ -733,8 +733,8 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 	{
 		if (!P.DoAdunitBoundaries) P.NumAdunits = 0;
 		//		if(!(dat2=fopen("EnvTest.txt","w"))) ERR_CRITICAL("Unable to open test file\n");
-		fprintf(stderr, "Density file contains %i datapoints.\n", (int)P.BinFileLen);
-		for (rn = rn2 = mr = 0; rn < P.BinFileLen; rn++)
+		fprintf(stderr, "Density file contains %i datapoints.\n", (int)P.binary_file_size);
+		for (rn = rn2 = mr = 0; rn < P.binary_file_size; rn++)
 		{
 			int k;
 			x = BF[rn].x; y = BF[rn].y; t = BF[rn].pop; country = BF[rn].cnt; j2 = BF[rn].ad;
@@ -808,19 +808,19 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		}
 		//		fclose(dat2);
 		fprintf(stderr, "%i valid microcells read from density file.\n", mr);
-		if ((P.OutputDensFile) && (P.DoBin)) P.BinFileLen = rn2;
+		if ((P.OutputDensFile) && (P.DoBin)) P.binary_file_size = rn2;
 		if (P.DoBin == 0)
 		{
 			if (P.OutputDensFile)
 			{
 				free(BinFileBuf);
 				P.DoBin = 1;
-				P.BinFileLen = 0;
+				P.binary_file_size = 0;
 				for (l = 0; l < P.NMC; l++)
-					if (mcell_adunits[l] >= 0) P.BinFileLen++;
-				if (!(BinFileBuf = (void*)malloc(P.BinFileLen * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
+					if (mcell_adunits[l] >= 0) P.binary_file_size++;
+				if (!(BinFileBuf = (void*)malloc(P.binary_file_size * sizeof(BinFile)))) ERR_CRITICAL("Unable to allocate binary file buffer\n");
 				BF = (BinFile*)BinFileBuf;
-				fprintf(stderr, "Binary density file should contain %i microcells.\n", (int)P.BinFileLen);
+				fprintf(stderr, "Binary density file should contain %i microcells.\n", (int)P.binary_file_size);
 				rn = 0;
 				for (l = 0; l < P.NMC; l++)
 					if (mcell_adunits[l] >= 0)
@@ -840,9 +840,9 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 			if (!(dat2 = fopen(OutDensFile, "wb"))) ERR_CRITICAL("Unable to open output density file\n");
 			rn = 0xf0f0f0f0;
 			fwrite_big((void*)& rn, sizeof(unsigned int), 1, dat2);
-			fprintf(stderr, "Saving population density file with NC=%i...\n", (int)P.BinFileLen);
-			fwrite_big((void*) & (P.BinFileLen), sizeof(unsigned int), 1, dat2);
-			fwrite_big(BinFileBuf, sizeof(BinFile), (size_t)P.BinFileLen, dat2);
+			fprintf(stderr, "Saving population density file with NC=%i...\n", (int)P.binary_file_size);
+			fwrite_big((void*) & (P.binary_file_size), sizeof(unsigned int), 1, dat2);
+			fwrite_big(BinFileBuf, sizeof(BinFile), (size_t)P.binary_file_size, dat2);
 			fclose(dat2);
 		}
 		free(BinFileBuf);

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -291,7 +291,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 	double fp; //// false positive
 	unsigned short int ts;
 
-	if (!P.DoSeasonality)	seasonality = 1.0;
+	if (!P.respect_seasonality_variations) seasonality = 1.0;
 	else					seasonality = P.Seasonality[((int)t) % DAYS_PER_YEAR];
 
 	ts = (unsigned short int) (P.TimeStepsPerDay * t);

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -192,7 +192,7 @@ void TravelDepartSweep(double t)
 		for (int tn = 0; tn < P.NumThreads; tn++)
 			for (int i = tn; i < P.Nplace[P.HotelPlaceType]; i += P.NumThreads)
 			{
-				int c = ((int)(Places[P.HotelPlaceType][i].loc_x / P.in_cells_.width_)) * P.nch + ((int)(Places[P.HotelPlaceType][i].loc_y / P.in_cells_.height_));
+				int c = ((int)(Places[P.HotelPlaceType][i].loc_x / P.in_cells_.width_)) * P.cell_grid_height + ((int)(Places[P.HotelPlaceType][i].loc_y / P.in_cells_.height_));
 				int n = (int)ignpoi_mt(nl * Cells[c].tot_prob, tn);
 				if (Places[P.HotelPlaceType][i].n + n > mps)
 				{

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -1292,7 +1292,7 @@ int TreatSweep(double t)
 #pragma omp parallel for private(f2,f3,f4,r) reduction(+:f) schedule(static,1) default(none) \
 			shared(t, P, Hosts, Mcells, McellLookup, AdUnits, State, global_trig, ts, tstf, tstb, tsvb, tspf, tsmf, tsmb, tssdf, tskwpf, nckwp)
 		for (int tn = 0; tn < P.NumThreads; tn++)
-			for (int bs = tn; bs < P.NMCP; bs += P.NumThreads) //// loop over populated microcells
+			for (int bs = tn; bs < P.populated_microcells_count; bs += P.NumThreads) //// loop over populated microcells
 			{
 				int b = (int)(McellLookup[bs] - Mcells); //// microcell number
 				int adi = (P.DoAdUnits) ? Mcells[b].adunit : -1;

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -42,7 +42,7 @@ void TravelReturnSweep(double t)
 					if (Hosts[i].Travelling == l)
 					{
 						n--;
-						/*						if((n<0)||(Places[P.HotelPlaceType][j].members[n]<0)||(Places[P.HotelPlaceType][j].members[n]>=P.PopSize))
+						/*						if((n<0)||(Places[P.HotelPlaceType][j].members[n]<0)||(Places[P.HotelPlaceType][j].members[n]>=P.population_size))
 													{fprintf(stderr,"### %i %i %i %i\n",j,k,n,Places[P.HotelPlaceType][j].members[n]);ner++;}
 												else if((k<0)||(k>n))
 													{fprintf(stderr,"@ %i %i %i %i\n",j,k,n,Places[P.HotelPlaceType][j].members[n]);ner++;}
@@ -1206,7 +1206,7 @@ int TreatSweep(double t)
 	if (P.DoGlobalTriggers)
 	{
 		if (P.DoPerCapitaTriggers)
-			global_trig = (int)floor(((double)State.trigDC) * P.GlobalIncThreshPop / ((double)P.PopSize));
+			global_trig = (int)floor(((double)State.trigDC) * P.GlobalIncThreshPop / ((double)P.population_size));
 		else
 			global_trig = State.trigDC;
 	}
@@ -1231,7 +1231,7 @@ int TreatSweep(double t)
 						f = StateT[i].pg_queue[j][k];
 						for (int m = ((int)Places[j][l].group_start[f]); m < ((int)(Places[j][l].group_start[f] + Places[j][l].group_size[f])); m++)
 						{
-							/*							if((Places[j][l].members[m]<0)||(Places[j][l].members[m]>P.PopSize-1))
+							/*							if((Places[j][l].members[m]<0)||(Places[j][l].members[m]>P.population_size-1))
 															fprintf(stderr,"\n*** npq=%i gn=%i h=%i m=%i j=%i l=%i f=%i s=%i n=%i ***\n",
 																StateT[i].np_queue[j],
 																Places[j][l].n,

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -303,7 +303,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 #pragma omp parallel for private(n,f,f2,s,s2,s3,s4,s5,s6,cq,ci,s3_scaled,s4_scaled) schedule(static,1) default(none) \
 		shared(t, P, CellLookup, Hosts, AdUnits, Households, Places, SamplingQueue, Cells, Mcells, StateT, hbeta, sbeta, seasonality, ts, fp, bm, stderr_shared)
 	for (int tn = 0; tn < P.NumThreads; tn++)
-		for (int b = tn; b < P.NCP; b += P.NumThreads) //// loop over (in parallel) all populated cells. Loop 1)
+		for (int b = tn; b < P.populated_cells_count; b += P.NumThreads) //// loop over (in parallel) all populated cells. Loop 1)
 		{
 			Cell* c = CellLookup[b];
 			s5 = 0; ///// spatial infectiousness summed over all infectious people in loop below
@@ -782,7 +782,7 @@ void IncubRecoverySweep(double t, int run)
 
 #pragma omp parallel for schedule(static,1) default(none) shared(t, run, P, CellLookup, Hosts, AdUnits, Mcells, StateT, ts)
 	for (int tn = 0; tn < P.NumThreads; tn++)	//// loop over threads
-		for (int b = tn; b < P.NCP; b += P.NumThreads)	//// loop/step over populated cells
+		for (int b = tn; b < P.populated_cells_count; b += P.NumThreads)	//// loop/step over populated cells
 		{
 			Cell* c = CellLookup[b]; //// find (pointer-to) cell.
 			for (int j = ((int)c->L - 1); j >= 0; j--) //// loop backwards over latently infected people, hence it starts from L - 1 and goes to zero. Runs backwards because of pointer swapping?

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1215,7 +1215,7 @@ void DoPlaceClose(int i, int j, unsigned short int ts, int tn, int DoAnyway)
 						if (Hosts[ai].ProbCare < P.CaseAbsentChildPropAdultCarers) //// if child needs adult supervision
 						{
 							j1 = Households[Hosts[ai].hh].FirstPerson; j2 = j1 + Households[Hosts[ai].hh].nh;
-							if ((j1 < 0) || (j2 > P.PopSize)) fprintf(stderr, "++ %i %i %i (%i %i %i)##  ", ai, j1, j2, i, j, k);
+							if ((j1 < 0) || (j2 > P.population_size)) fprintf(stderr, "++ %i %i %i (%i %i %i)##  ", ai, j1, j2, i, j, k);
 							f = 0;
 
 							//// in loop below, f true if any household member a) alive AND b) not a child AND c) has no links to workplace (or is absent from work or quarantined).


### PR DESCRIPTION
### Rename multiple parameters in `Param.h`.

Currently using `snake_case` for `struct Param` in `Param.h` because there is evidence of *multiple* naming conventions for different parameters: `PascalCase`, `camelCase`, `PascalCase_WithUnderscore`, etc., can be changed if there is a official code style guide.

### Refactor Scope

This PR is strictly restricted to *parameter naming changes*, and does not intend to refactor `struct Param` into smaller `struct`s and `enum`s. Future PRs are planned to split the work into multiple stages for easier review and testing. This PR should **not** change any type signatures and thus should **not** perform any semantic/behavioural changes.

This PR also attempts to minimize reformatting to minimize the diffs. A proper reformatting tool such as `clang-format` should be used as a follow-up PR to do an overall reformat due to changes in line length resulting from parameter name changes.

### TODOs

- Some parameter are not yet renamed, because:
    - I could not derive their intended **purpose** and **units of measurement** from existing documentation or from call sites / usage locations (some of them don't have documentation that I can find from `docs/` or from other issues / PRs).
    - Still debating on a good name for the parameter.

### Refactor Opportunities for Follow-up PRs

- `KernelType` really should be an `enum`. It seems that `KernelType` also determines which function should be used, so a compile-time function lookup table might be useful here.