### PR TITLE
Refactor some variable shadowing

### DIFF
--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -836,9 +836,13 @@ void DoCase(int ai, double t, unsigned short int ts, int tn) //// makes an infec
 						if (P.AbsenteeismPlaceClosure)
 						{
 							if ((t >= P.PlaceCloseTimeStart) && (!P.DoAdminTriggers) && (!P.DoGlobalTriggers))
-								for (j = 0; j < P.PlaceTypeNum; j++)
-									if ((j != P.HotelPlaceType) && (a->PlaceLinks[j] >= 0))
-											DoPlaceClose(j, a->PlaceLinks[j], ts, tn, 0);
+							{
+								for (int place_type = 0; place_type < P.PlaceTypeNum; place_type++)
+									if ((place_type != P.HotelPlaceType) && (a->PlaceLinks[place_type] >= 0))
+										DoPlaceClose(place_type, a->PlaceLinks[place_type], ts, tn, 0);
+								
+								j = P.PlaceTypeNum;
+							}
 						}
 						if ((!HOST_QUARANTINED(ai)) && (Hosts[ai].PlaceLinks[P.PlaceTypeNoAirNum - 1] >= 0) && (HOST_AGE_YEAR(ai) >= P.CaseAbsentChildAgeCutoff))
 							StateT[tn].cumAC++;
@@ -851,12 +855,13 @@ void DoCase(int ai, double t, unsigned short int ts, int tn) //// makes an infec
 							{
 								j1 = Households[Hosts[ai].hh].FirstPerson; j2 = j1 + Households[Hosts[ai].hh].nh;
 								f = 0;
-								for (int j = j1; (j < j2) && (!f); j++)
-									f = ((abs(Hosts[j].inf) != InfStat_Dead) && (HOST_AGE_YEAR(j) >= P.CaseAbsentChildAgeCutoff) && ((Hosts[j].PlaceLinks[P.PlaceTypeNoAirNum - 1] < 0)|| (HOST_ABSENT(j)) || (HOST_QUARANTINED(j))));
+								for (int j3 = j1; (j3 < j2) && (!f); j3++)
+									f = ((abs(Hosts[j3].inf) != InfStat_Dead) && (HOST_AGE_YEAR(j3) >= P.CaseAbsentChildAgeCutoff)
+										&& ((Hosts[j3].PlaceLinks[P.PlaceTypeNoAirNum - 1] < 0)|| (HOST_ABSENT(j3)) || (HOST_QUARANTINED(j3))));
 								if (!f)
 								{
-									for (int j = j1; (j < j2) && (!f); j++)
-										if ((HOST_AGE_YEAR(j) >= P.CaseAbsentChildAgeCutoff) && (abs(Hosts[j].inf) != InfStat_Dead)) { k = j; f = 1; }
+									for (int j3 = j1; (j3 < j2) && (!f); j3++)
+										if ((HOST_AGE_YEAR(j3) >= P.CaseAbsentChildAgeCutoff) && (abs(Hosts[j3].inf) != InfStat_Dead)) { k = j3; f = 1; }
 									if (f)
 									{
 										if (!HOST_ABSENT(k)) Hosts[k].absent_start_time = ts + P.usCaseIsolationDelay;
@@ -867,7 +872,7 @@ void DoCase(int ai, double t, unsigned short int ts, int tn) //// makes an infec
 							}
 						}
 					}
-				}
+				} // End of if, and for(j)
 		}
 
 		//added some case detection code here: ggilani - 03/02/15


### PR DESCRIPTION
This removes some variable shadowing observed in #169 and #188 - variable j is reused, the first one sharing the outer loop j, and two more that declare a new scoped j. 

There may be further ways to clean this up, and make it more clear in due course; for now I have only tried to make explicit what was previously happening (namely, exit value of j from the first loop being set). 

From discussions, there is no code issue here, just clarity.