### PR TITLE
Run without population file

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -519,7 +519,13 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 		P.NumNonExtinctRealisations = P.NumRealisations;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Maximum number of cases defining small outbreak", "%i", (void*) & (P.SmallEpidemicCases), 1, 1, 0)) P.SmallEpidemicCases = -1;
 
-	P.NC = -1;
+	if (P.DoHeteroDensity) {
+	  P.NC = -1;
+	} else {
+	  GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of cells wide", "%i", (void*) & (P.ncw), 1, 1, 0);
+	  GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of cells high", "%i", (void*) & (P.nch), 1, 1, 0);
+	  P.NC = P.ncw * P.nch;
+	}
 	GetInputParameter(ParamFile_dat, PreParamFile_dat, "Number of micro-cells per spatial cell width", "%i", (void*) & (P.NMCL), 1, 1, 0);
 	//added parameter to reset seeds after every run
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Reset seeds for every run", "%i", (void*) & (P.ResetSeeds), 1, 1, 0)) P.ResetSeeds = 0;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -1266,6 +1266,7 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = 1.0;
 	}
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Grid size", "%lf", (void*) & (P.in_cells_.width_), 1, 1, 0)) P.in_cells_.width_ = 1.0 / 120.0;
+  P.in_cells_.height_ = P.in_cells_.width_;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Use long/lat coord system", "%i", (void*) & (P.DoUTM_coords), 1, 1, 0)) P.DoUTM_coords = 1;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Bitmap scale", "%lf", (void*) & (P.BitmapScale), 1, 1, 0)) P.BitmapScale = 1.0;
 	if (!GetInputParameter2(ParamFile_dat, PreParamFile_dat, "Bitmap y:x aspect scaling", "%lf", (void*) & (P.BitmapAspectScale), 1, 1, 0)) P.BitmapAspectScale = 1.0;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -164,14 +164,15 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 	}
 	else
 	{
-		P.ncw = P.nch = (int)sqrt((double)P.NC);
-		P.NC = P.ncw * P.nch;
-		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.NC, P.ncw);
 		s = floor(sqrt((double)P.PopSize));
-		P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 0;
-		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = s;
 		P.PopSize = (int)(s * s);
 		fprintf(stderr, "Population size adjusted to be %i (%lg^2)\n", P.PopSize, s);
+		P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 0;
+		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = s;
+		P.ncw = ceil((P.SpatialBoundingBox[2] - P.SpatialBoundingBox[0]) / P.in_cells_.width_);
+    P.nch = ceil((P.SpatialBoundingBox[3] - P.SpatialBoundingBox[1]) / P.in_cells_.height_);
+		P.NC = P.ncw * P.nch;
+		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.NC, P.ncw);
 		P.in_degrees_.width_ = P.in_degrees_.height_ = s;
 		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
 		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -137,7 +137,6 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 			if (!P.DoSpecifyPop) P.PopSize = (int)s2;
 		}
 
-		P.in_cells_.height_ = P.in_cells_.width_;
 		P.SpatialBoundingBox[0] = floor(P.SpatialBoundingBox[0] / P.in_cells_.width_) * P.in_cells_.width_;
 		P.SpatialBoundingBox[1] = floor(P.SpatialBoundingBox[1] / P.in_cells_.height_) * P.in_cells_.height_;
 		P.SpatialBoundingBox[2] = ceil(P.SpatialBoundingBox[2] / P.in_cells_.width_) * P.in_cells_.width_;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -998,23 +998,22 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 		fprintf(stderr, "Population size reset from %i to %i\n", i, P.PopSize);
 	}
 	t = 1.0;
-	for (int i = m = 0; i < (P.NMC - 1); i++)
+	for (int i = m = 0; i < P.NMC; i++)
 	{
-		s = mcell_dens[i] / maxd / t;
-		if (s > 1.0) s = 1.0;
-		m += (Mcells[i].n = (int)ignbin_mt((int32_t)(P.PopSize - m), s, 0));
-		t -= mcell_dens[i] / maxd;
+	  if (i == P.NMC-1) {
+      Mcells[P.NMC - 1].n = P.PopSize - m;
+	  } else {
+      s = mcell_dens[i] / maxd / t;
+      if (s > 1.0) s = 1.0;
+      m += (Mcells[i].n = (int)ignbin_mt((int32_t)(P.PopSize - m), s, 0));
+      t -= mcell_dens[i] / maxd;
+		}
+
 		if (Mcells[i].n > 0) {
 			P.NMCP++;
-			if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
-			AdUnits[mcell_adunits[i]].n += Mcells[i].n;
+      if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
+      AdUnits[mcell_adunits[i]].n += Mcells[i].n;
 		}
-	}
-	Mcells[P.NMC - 1].n = P.PopSize - m;
-	if (Mcells[P.NMC - 1].n > 0)
-	{
-		P.NMCP++;
-		AdUnits[mcell_adunits[P.NMC - 1]].n += Mcells[P.NMC - 1].n;
 	}
 
 	free(mcell_dens);

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -150,33 +150,26 @@ void SetupModel(char* DensityFile, char* NetworkFile, char* SchoolFile, char* Re
 		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[0] + P.in_degrees_.width_;
 		P.SpatialBoundingBox[3] = P.SpatialBoundingBox[1] + P.in_degrees_.height_;
 		P.NC = P.ncw * P.nch;
-		fprintf(stderr, "Adjusted bounding box = (%lg, %lg)- (%lg, %lg)\n", P.SpatialBoundingBox[0], P.SpatialBoundingBox[1], P.SpatialBoundingBox[2], P.SpatialBoundingBox[3]);
-		fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.NC, P.ncw, P.nch);
-		fprintf(stderr, "Population size = %i \n", P.PopSize);
-		if (P.in_degrees_.width_ > 180) {
-			fprintf(stderr, "WARNING: Width of bounding box > 180 degrees.  Results may be inaccurate.\n");
-		}
-		if (P.in_degrees_.height_ > 90) {
-			fprintf(stderr, "WARNING: Height of bounding box > 90 degrees.  Results may be inaccurate.\n");
-		}
 		s = 1;
 		P.DoPeriodicBoundaries = 0;
 	}
 	else
 	{
-		s = floor(sqrt((double)P.PopSize));
-		P.PopSize = (int)(s * s);
-		fprintf(stderr, "Population size adjusted to be %i (%lg^2)\n", P.PopSize, s);
 		P.SpatialBoundingBox[0] = P.SpatialBoundingBox[1] = 0;
-		P.SpatialBoundingBox[2] = P.SpatialBoundingBox[3] = s;
-		P.ncw = ceil((P.SpatialBoundingBox[2] - P.SpatialBoundingBox[0]) / P.in_cells_.width_);
-    P.nch = ceil((P.SpatialBoundingBox[3] - P.SpatialBoundingBox[1]) / P.in_cells_.height_);
-		P.NC = P.ncw * P.nch;
-		fprintf(stderr, "Number of cells adjusted to be %i (%i^2)\n", P.NC, P.ncw);
-		P.in_degrees_.width_ = P.in_degrees_.height_ = s;
-		P.in_cells_.width_ = P.in_degrees_.width_ / ((double)P.ncw);
-		P.in_cells_.height_ = P.in_degrees_.height_ / ((double)P.nch);
+		P.SpatialBoundingBox[2] = P.in_degrees_.width_ = P.ncw * P.in_cells_.width_;
+		P.SpatialBoundingBox[3] = P.in_degrees_.height_ = P.nch * P.in_cells_.height_;
 	}
+
+  fprintf(stderr, "Adjusted bounding box = (%lg, %lg)- (%lg, %lg)\n", P.SpatialBoundingBox[0], P.SpatialBoundingBox[1], P.SpatialBoundingBox[2], P.SpatialBoundingBox[3]);
+  fprintf(stderr, "Number of cells = %i (%i x %i)\n", P.NC, P.ncw, P.nch);
+  fprintf(stderr, "Population size = %i \n", P.PopSize);
+  if (P.in_degrees_.width_ > 180) {
+    fprintf(stderr, "WARNING: Width of bounding box > 180 degrees.  Results may be inaccurate.\n");
+  }
+  if (P.in_degrees_.height_ > 90) {
+    fprintf(stderr, "WARNING: Height of bounding box > 90 degrees.  Results may be inaccurate.\n");
+  }
+
 	P.NMC = P.NMCL * P.NMCL * P.NC;
 	fprintf(stderr, "Number of microcells = %i\n", P.NMC);
 	P.scalex = P.BitmapScale;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1011,8 +1011,10 @@ void SetupPopulation(char* SchoolFile, char* RegDemogFile)
 
 		if (Mcells[i].n > 0) {
 			P.NMCP++;
-      if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
-      AdUnits[mcell_adunits[i]].n += Mcells[i].n;
+			if (P.DoAdUnits) {
+        if (mcell_adunits[i] < 0) ERR_CRITICAL_FMT("Cell %i has adunits < 0 (indexing AdUnits)\n", i);
+        AdUnits[mcell_adunits[i]].n += Mcells[i].n;
+      }
 		}
 	}
 


### PR DESCRIPTION
Currently it is difficult to configure a quick, basic simulation. This sort of thing would be useful for creating regression tests that target particular features.

This PR involves a few changes and probably will need some tidying:
- require that without a population file you supply the simulation grid width and height (rather than inferring it from the population size, which ended up with a very sparse grid, depending on number of microcells per cell)
-  set height and width of cells (P.in_cells_) immediately after reading the parameter, or inferring the default
- refactor population allocation loop to incorporate the last iteration. (I would love to rename some variables here, but thought it might be easier to follow without including in this PR)
- only validate adunit values if adunits are being included in the simulation

These changes allowed me to run a simulation from some really stripped down parameter files, albeit without any means (I think) for infection to spread across cell boundaries. I am also limited to a low infectious period by the MAX_INFECTIOUS_STEPS validation (different validation according to whether P.DoInfectiousnessProfile is set, which I am avoiding for a minimal config).

Keen for some feedback - am I on the right lines?

A possible fix for https://github.com/mrc-ide/covid-sim/issues/337