### PR TITLE
Fix alignment in struct Household

### DIFF
--- a/src/Model.h
+++ b/src/Model.h
@@ -58,8 +58,8 @@ struct Household
 {
 	int FirstPerson;
 	unsigned short int nh; // number people in household
-	float loc_x, loc_y;
 	unsigned short int nhr;
+	float loc_x, loc_y;
 };
 
 /*


### PR DESCRIPTION
In Model.h there is a two byte packing pragma. In struct Household, that currently means
that the two floats are misaligned. That is based on int being 32 bits, and short being
16 bits, and float being 32 bits.

There is a simple solution to this, by pairing up the two short fields, that makes 32
bits and the two floats are then properly aligned. It may be possible to remove the
two byte packing pragma too, however this will affect other structures and I've not
yet reviewed those. So this a minimal change to fix this one issue.

Note that this will make snapshots incompatible from previous versions.