### PR TITLE
Simplify Param::get_micro_cell_index_from_position

### DIFF
--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -22,7 +22,5 @@ bool Param::is_in_bounds(MicroCellPosition position) const {
 }
 
 int Param::get_micro_cell_index_from_position(MicroCellPosition position) const {
-	int x = (position.x + this->get_number_of_micro_cells_wide()) % this->get_number_of_micro_cells_wide();
-	int y = (position.y + this->get_number_of_micro_cells_high()) % this->get_number_of_micro_cells_high();
-	return x * this->get_number_of_micro_cells_high() + y;
+	return position.x * this->get_number_of_micro_cells_high() + position.y;
 }


### PR DESCRIPTION
If the function doesn't have some hidden logic behind it, then it can be simplified based on the fact that
(a + b) % b = a % b + b % b = a % b
