### PR TITLE
Fix issue with initialisation of inv journey dists

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -891,14 +891,16 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 				P.JourneyDurationDistrib[i] += P.JourneyDurationDistrib[i - 1];
 				P.LocalJourneyDurationDistrib[i] += P.LocalJourneyDurationDistrib[i - 1];
 			}
-			for (i = j = 0; i <= 1024; i++)
+			for (i = 0; i <= 1024; i++)
 			{
+				int j = 0;
 				s = ((double)i) / 1024;
 				while (P.JourneyDurationDistrib[j] < s)j++;
 				P.InvJourneyDurationDistrib[i] = j;
 			}
-			for (i = j = 0; i <= 1024; i++)
+			for (i = 0; i <= 1024; i++)
 			{
+				int j = 0;
 				s = ((double)i) / 1024;
 				while (P.LocalJourneyDurationDistrib[j] < s)j++;
 				P.InvLocalJourneyDurationDistrib[i] = j;
@@ -4779,7 +4781,7 @@ void RecordSample(double t, int n)
 	if (P.DoAdUnits && P.OutputAdUnitAge)
 		RecordAdminAgeBreakdowns(n);
 
-	RecordQuarNotInfected(n, ts); 
+	RecordQuarNotInfected(n, ts);
 
 	if (P.DoSeverity)
 	{


### PR DESCRIPTION
I noticed this whilst reviewing #400, and I'm not sure if it is a bug or not - @NeilFerguson I would appreciate your review.

I believe it **doesn't** affect any simulations published to date as it requires airports to be enabled - which they haven't been for CovidSim.

In the two loops starting at line 894 of src/CovidSim.cpp initialising `InvJourneyDurationDistrib` and `InvLocalJourneyDurationDistrib`, the variable `j` is initialised to `0` at the head of the loop and then used to find an appropriate index in the `while` loop, which is used to set the value of `Inv...[i]`.

The issue is `j` is not reset each go round the loop.  Therefore `Inv...[i - 1] <= Inv...[i]` (j is always increasing).

I am not sure whether this is a bug or not.  I think it probably is and so have made the proposed change - but @NeilFerguson can you please confirm?