### PR TITLE
Use enum struct for InfStat

### DIFF
--- a/src/CalcInfSusc.cpp
+++ b/src/CalcInfSusc.cpp
@@ -21,7 +21,7 @@ double CalcPlaceInf(int j, int k, unsigned short int ts)
 	return	((HOST_ISOLATED(j) && (Hosts[j].digitalContactTraced != 1)) ? P.CaseIsolationEffectiveness : 1.0)
 		*	((Hosts[j].digitalContactTraced==1) ? P.DCTCaseIsolationEffectiveness : 1.0)
 		*	((HOST_QUARANTINED(j) && (Hosts[j].digitalContactTraced != 1) && (!(HOST_ISOLATED(j)))) ? P.HQuarantinePlaceEffect[k] : 1.0)
-		*	((Hosts[j].inf == InfStat_Case) ? P.SymptPlaceTypeContactRate[k] : 1.0)
+		*	((Hosts[j].inf == InfStat::Case) ? P.SymptPlaceTypeContactRate[k] : 1.0)
 		*	P.PlaceTypeTrans[k] / P.PlaceTypeGroupSizeParam1[k] * CalcPersonInf(j, ts);
 }
 double CalcSpatialInf(int j, unsigned short int ts)
@@ -29,7 +29,7 @@ double CalcSpatialInf(int j, unsigned short int ts)
 	return	((HOST_ISOLATED(j) && (Hosts[j].digitalContactTraced != 1)) ? P.CaseIsolationEffectiveness : 1.0)
 		*	((Hosts[j].digitalContactTraced==1) ? P.DCTCaseIsolationEffectiveness : 1.0)
 		*   ((HOST_QUARANTINED(j) && (Hosts[j].digitalContactTraced != 1) && (!(HOST_ISOLATED(j)))) ? P.HQuarantineSpatialEffect : 1.0)
-		*	((Hosts[j].inf == InfStat_Case) ? P.SymptSpatialContactRate : 1.0)
+		*	((Hosts[j].inf == InfStat::Case) ? P.SymptSpatialContactRate : 1.0)
 		*	P.RelativeSpatialContact[HOST_AGE_GROUP(j)]
 		*	CalcPersonInf(j, ts); 		/*	*Hosts[j].spatial_norm */
 }

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2489,7 +2489,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 			Hosts[k].detected = 0; //set detected to zero initially: ggilani - 19/02/15
 			Hosts[k].detected_time = 0;
 			Hosts[k].digitalContactTraced = 0;
-			Hosts[k].inf = InfStat_Susceptible;
+			Hosts[k].inf = InfStat::Susceptible;
 			Hosts[k].num_treats = 0;
 			Hosts[k].latent_time = Hosts[k].recovery_or_death_time = 0; //also set hospitalisation time to zero: ggilani 28/10/2014
 			Hosts[k].infector = -1;
@@ -2506,7 +2506,7 @@ void InitModel(int run) // passing run number so we can save run number in the i
 				Hosts[k].RecoveringFromCritical_time = USHRT_MAX - 1;
 				Hosts[k].Severity_Current = Severity::Asymptomatic;
 				Hosts[k].Severity_Final = Severity::Asymptomatic;
-				Hosts[k].inf = InfStat_Susceptible;
+				Hosts[k].inf = InfStat::Susceptible;
 			}
 		}
 
@@ -2724,7 +2724,7 @@ void SeedInfection(double t, int* NumSeedingInfections_byLocation, int rf, int r
 			for (k = 0; (k < NumSeedingInfections_byLocation[i]) && (m < 10000); k++)
 			{
 				l = Mcells[j].members[(int)(ranf() * ((double)Mcells[j].n))]; //// randomly choose member of microcell j. Name this member l
-				if (Hosts[l].inf == InfStat_Susceptible) //// If Host l is uninfected.
+				if (Hosts[l].inf == InfStat::Susceptible) //// If Host l is uninfected.
 				{
 					if (CalcPersonSusc(l, 0, 0, 0) > 0)
 					{
@@ -2760,7 +2760,7 @@ void SeedInfection(double t, int* NumSeedingInfections_byLocation, int rf, int r
 				for (k = 0; (k < NumSeedingInfections_byLocation[i]) && (m < 10000); k++)
 				{
 					l = Mcells[j].members[(int)(ranf() * ((double)Mcells[j].n))];
-					if (Hosts[l].inf == InfStat_Susceptible)
+					if (Hosts[l].inf == InfStat::Susceptible)
 					{
 						if (CalcPersonSusc(l, 0, 0, 0) > 0)
 						{
@@ -2796,7 +2796,7 @@ void SeedInfection(double t, int* NumSeedingInfections_byLocation, int rf, int r
 					|| (Mcells[j].n < P.MinPopDensForInitialInfection)
 					|| ((P.InitialInfectionsAdminUnit[i] > 0) && ((AdUnits[Mcells[j].adunit].id % P.AdunitLevel1Mask) / P.AdunitLevel1Divisor != (P.InitialInfectionsAdminUnit[i] % P.AdunitLevel1Mask) / P.AdunitLevel1Divisor)));
 				l = Mcells[j].members[(int)(ranf() * ((double)Mcells[j].n))];
-				if (Hosts[l].inf == InfStat_Susceptible)
+				if (Hosts[l].inf == InfStat::Susceptible)
 				{
 					if (CalcPersonSusc(l, 0, 0, 0) > 0)
 					{
@@ -2848,8 +2848,8 @@ int RunModel(int run, std::string const& snapshot_save_file, std::string const& 
 			}
 			else
 			{
-				if ((Hosts[i].listpos > Cells[Hosts[i].pcell].S - 1) && (Hosts[i].inf == InfStat_Susceptible)) i2++;
-				if ((Hosts[i].listpos < Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I - 1) && (abs(Hosts[i].inf) == InfStat_Recovered)) i2++;
+				if ((Hosts[i].listpos > Cells[Hosts[i].pcell].S - 1) && (Hosts[i].inf == InfStat::Susceptible)) i2++;
+				if ((Hosts[i].listpos < Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I - 1) && (abs(Hosts[i].inf) == InfStat::Recovered)) i2++;
 			}
 			if ((Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I + Cells[Hosts[i].pcell].R + Cells[Hosts[i].pcell].D) != Cells[Hosts[i].pcell].n)
 			{
@@ -2925,7 +2925,7 @@ int RunModel(int run, std::string const& snapshot_save_file, std::string const& 
 								do
 								{
 									l = (int)(((double)P.PopSize) * ranf()); //// choose person l randomly from entire population. (but change l if while condition not satisfied?)
-								} while ((abs(Hosts[l].inf) == InfStat_Dead) || (ranf() > P.FalsePositiveAgeRate[HOST_AGE_GROUP(l)]));
+								} while ((abs((int) Hosts[l].inf) == (int) InfStat::Dead) || (ranf() > P.FalsePositiveAgeRate[HOST_AGE_GROUP(l)]));
 								DoFalseCase(l, t, ts, 0);
 							}
 						}
@@ -2996,8 +2996,8 @@ int RunModel(int run, std::string const& snapshot_save_file, std::string const& 
 				}
 				else
 				{
-					if ((Hosts[i].listpos > Cells[Hosts[i].pcell].S - 1) && (Hosts[i].inf == InfStat_Susceptible)) i2++;
-					if ((Hosts[i].listpos < Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I - 1) && (abs(Hosts[i].inf) == InfStat_Recovered)) i2++;
+					if ((Hosts[i].listpos > Cells[Hosts[i].pcell].S - 1) && (Hosts[i].inf == InfStat::Susceptible)) i2++;
+					if ((Hosts[i].listpos < Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I - 1) && (abs(Hosts[i].inf) == InfStat::Recovered)) i2++;
 				}
 				if ((Cells[Hosts[i].pcell].S + Cells[Hosts[i].pcell].L + Cells[Hosts[i].pcell].I + Cells[Hosts[i].pcell].R + Cells[Hosts[i].pcell].D) != Cells[Hosts[i].pcell].n)
 				{
@@ -4505,8 +4505,8 @@ void RecordQuarNotInfected(int n, unsigned short int ts)
 		for (int Person = thread_no; Person < P.PopSize; Person += P.NumThreads)
 			if (HOST_QUARANTINED(Person))
 			{
-				if (Hosts[Person].inf == InfStat_Susceptible || abs(Hosts[Person].inf) == InfStat_Recovered) QuarNotInfected++;
-				if (Hosts[Person].inf > 0) QuarNotSymptomatic++;
+				if (Hosts[Person].inf == InfStat::Susceptible || abs((int) Hosts[Person].inf) == (int) InfStat::Recovered) QuarNotInfected++;
+				if ((int) Hosts[Person].inf > 0) QuarNotSymptomatic++;
 			}
 
 	TimeSeries[n].prevQuarNotInfected		= (double) QuarNotInfected;
@@ -5176,16 +5176,16 @@ void RecordInfTypes(void)
 		{
 			//				i=Cells[b].members[c];
 			if (j == 0) j = k = Households[Hosts[i].hh].nh;
-			if ((Hosts[i].inf != InfStat_Susceptible) && (Hosts[i].inf != InfStat_ImmuneAtStart))
+			if ((Hosts[i].inf != InfStat::Susceptible) && (Hosts[i].inf != InfStat::ImmuneAtStart))
 			{
 				if (Hosts[i].latent_time * P.TimeStep <= P.SampleTime)
 					TimeSeries[(int)(Hosts[i].latent_time * P.TimeStep / P.SampleStep)].Rdenom++;
 				infcountry[mcell_country[Hosts[i].mcell]]++;
-				if (abs(Hosts[i].inf) < InfStat_Recovered)
+				if (abs((int) Hosts[i].inf) < (int) InfStat::Recovered)
 					l = -1;
 				else if (l >= 0)
 					l++;
-				if ((l >= 0) && ((Hosts[i].inf == InfStat_RecoveredFromSymp) || (Hosts[i].inf == InfStat_Dead_WasSymp)))
+				if ((l >= 0) && ((Hosts[i].inf == InfStat::RecoveredFromSymp) || (Hosts[i].inf == InfStat::Dead_WasSymp)))
 				{
 					lc2++;
 					if (Hosts[i].latent_time * P.TimeStep <= t) // This convoluted logic is to pick up households where the index is symptomatic
@@ -5224,7 +5224,7 @@ void RecordInfTypes(void)
 			for (c = 0; c < Cells[b].n; c++)
 			{
 				i = Cells[b].members[c];
-				if ((abs(Hosts[i].inf) == InfStat_Recovered) || (abs(Hosts[i].inf) == InfStat_Dead))
+				if ((abs((int) Hosts[i].inf) == (int) InfStat::Recovered) || (abs((int) Hosts[i].inf) == (int) InfStat::Dead))
 				{
 					l = Hosts[i].infect_type / INFECT_TYPE_MASK;
 					if ((l < MAX_GEN_REC) && (Hosts[i].listpos < MAX_SEC_REC)) indivR0[Hosts[i].listpos][l]++;

--- a/src/InfStat.h
+++ b/src/InfStat.h
@@ -1,38 +1,38 @@
-#ifndef COVIDSIM_INFSTAT_H_INCLUDED_
-#define COVIDSIM_INFSTAT_H_INCLUDED_
+#ifndef COVIDSIM_H_INCLUDED_
+#define COVIDSIM_H_INCLUDED_
 
 //// Infection Status definitions / labels (generally positive value indicates asymptomatic infection,
 //// negative value indicates symptomatic infection).
 
-enum InfStat {
+enum struct InfStat {
 
 //// Note - DO NOT CHANGE these definitions without accounting for "Quarantined not Infected" /
 //// "Quarantined not symptomatic" calculation: relies on value below being negative for symptomatic people.
 
 	//// Susceptible
-	InfStat_Susceptible = 0,
+	Susceptible = 0,
 	//// Neither infectious nor symptomatic (E or L).
-	InfStat_Latent = 1,
+	Latent = 1,
 	//// Infectious and about to become a case.
-	InfStat_InfectiousAlmostSymptomatic = -1,
+	InfectiousAlmostSymptomatic = -1,
 	//// Not just asymptomatic, but also will not become symptomatic (i.e. a case)
-	InfStat_InfectiousAsymptomaticNotCase = 2,
+	InfectiousAsymptomaticNotCase = 2,
 	//// Case. Infectious and symptomatic.
-	InfStat_Case = -2,
+	Case = -2,
 	//// Recovered from asymptomatic infection
-	InfStat_RecoveredFromAsymp = 3,
+	RecoveredFromAsymp = 3,
 	//// Recovered from symptomatic infection
-	InfStat_RecoveredFromSymp = -3,
-	//// InfStat_Recovered (will use this for abs() values) so code reads correctly
-	InfStat_Recovered = 3,
+	RecoveredFromSymp = -3,
+	//// Recovered (will use this for abs() values) so code reads correctly
+	Recovered = 3,
 	//// Immune at start of epidemic - used to model partially immune population. Distinct from recovered, who recovered during runtime. Doesn't take negative values.
-	InfStat_ImmuneAtStart = 4,
+	ImmuneAtStart = 4,
 	//// Dead was asymptomatic
-	InfStat_Dead_WasAsymp = 5,
+	Dead_WasAsymp = 5,
 	//// Dead was symptomatic
-	InfStat_Dead_WasSymp = -5,
+	Dead_WasSymp = -5,
 	//// Dead (will use this for abs() values) so code reads correctly
-	InfStat_Dead = 5
+	Dead = 5
 };
 
 //// SeverityClass definitions / labels (numbers arbitrary but must be different to each other).
@@ -51,4 +51,4 @@ enum struct Severity {
 	Recovered
 };
 
-#endif // COVIDSIM_INFSTAT_H_INCLUDED_
+#endif // COVIDSIM_H_INCLUDED_

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -523,7 +523,7 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 				}
 				l = Households[Hosts[i].hh].FirstPerson;
 				m = l + Households[Hosts[i].hh].nh;
-				for (int k = l; k < m; k++) if ((Hosts[k].inf == InfStat_Susceptible) && (k != i)) s += (1 - d) * P.AgeSusceptibility[HOST_AGE_GROUP(i)];
+				for (int k = l; k < m; k++) if ((Hosts[k].inf == InfStat::Susceptible) && (k != i)) s += (1 - d) * P.AgeSusceptibility[HOST_AGE_GROUP(i)];
 			}
 			q = (P.LatentToSymptDelay > Hosts[i].recovery_or_death_time * P.TimeStep) ? Hosts[i].recovery_or_death_time * P.TimeStep : P.LatentToSymptDelay;
 			s2 = fabs(Hosts[i].infectiousness) * P.RelativeSpatialContact[HOST_AGE_GROUP(i)] * P.TimeStep;
@@ -1142,7 +1142,7 @@ void SetupPopulation(std::string const& density_file, std::string const& out_den
 				if (P.DoHouseholds)
 				{
 					for (i2 = 0; i2 < m; i2++) {
-						Hosts[i + i2].inf = InfStat_Susceptible; //added this so that infection status is set to zero and household r0 is correctly calculated
+						Hosts[i + i2].inf = InfStat::Susceptible; //added this so that infection status is set to zero and household r0 is correctly calculated
 					}
 				}
 				Households[Hosts[i].hh].FirstPerson = i;


### PR DESCRIPTION
I think `InfStat` can be reworked to avoid using `abs(InfStat::...)`, but I'd rather leave that for some next PR.