### PR TITLE
Refactor sinx, cosx, asin2sqx

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -2021,13 +2021,14 @@ void ReadParams(char* ParamFile, char* PreParamFile)
 	{
 		for (i = 0; i <= 1000; i++)
 		{
-			asin2sqx[i] = asin(sqrt(((double)(i)) / 1000));
+			asin2sqx[i] = asin(sqrt(i / 1000.0));
 			asin2sqx[i] = asin2sqx[i] * asin2sqx[i];
 		}
-		for (t = 0; t <= 360; t++)
+		for (i = 0; i <= DEGREES_PER_TURN; i++)
 		{
-			sinx[(int)t] = sin(PI * t / 180);
-			cosx[(int)t] = cos(PI * t / 180);
+			t = PI * i / 180;
+			sinx[i] = sin(t);
+			cosx[i] = cos(t);
 		}
 	}
 	fprintf(stderr, "Parameters read\n");

--- a/src/Dist.cpp
+++ b/src/Dist.cpp
@@ -7,7 +7,7 @@
 
 #include "Model.h"
 
-double sinx[361], cosx[361], asin2sqx[1001];
+double sinx[DEGREES_PER_TURN + 1], cosx[DEGREES_PER_TURN + 1], asin2sqx[1001];
 
 //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 //// **** DISTANCE FUNCTIONS (return distance-squared, which is input for every Kernel function)

--- a/src/Dist.h
+++ b/src/Dist.h
@@ -4,8 +4,9 @@
 #include "Models/Person.h"
 #include "Models/Cell.h"
 #include "Models/Microcell.h"
+#include "Constants.h"
 
-extern double sinx[361], cosx[361], asin2sqx[1001];
+extern double sinx[DEGREES_PER_TURN + 1], cosx[DEGREES_PER_TURN + 1], asin2sqx[1001];
 double dist2UTM(double, double, double, double);
 double dist2(Person*, Person*);
 double dist2_cc(Cell*, Cell*);


### PR DESCRIPTION
Uses already available `DEGREES_PER_TURN` constant, instead of using magical constants, and simplifies the loop that calculates the array values.