### PR TITLE
Use better if-else-elseif flow for model CalibIteration

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -5104,7 +5104,8 @@ void RecordSample(double t, int n)
 						if (k > 0) P.CaseOrDeathThresholdBeforeAlert = k;
 					}
 					else if (P.ModelCalibIteration >= 2) {
-						if (abs((RatioPredictedObserved - 1.0) <= DesiredAccuracy)) {
+						if ((((RatioPredictedObserved - 1.0) <= DesiredAccuracy) && (RatioPredictedObserved >= 1)) ||
+							(((1.0 - RatioPredictedObserved) <= DesiredAccuracy) && (RatioPredictedObserved < 1))) {
 							P.StopCalibration = 1;
 						}
 						else if (P.ModelCalibIteration % 2 == 0) // on even iterations, adjust timings

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -5100,7 +5100,7 @@ void RecordSample(double t, int n)
 					if (P.ModelCalibIteration == 0)
 					{
 						// rescale threshold
-						k = (int)(((double)P.CaseOrDeathThresholdBeforeAlert) / RatioPredictedObserved);
+						k = (int)(P.CaseOrDeathThresholdBeforeAlert / RatioPredictedObserved);
 						if (k > 0) P.CaseOrDeathThresholdBeforeAlert = k;
 					}
 					else if (P.ModelCalibIteration >= 2) {
@@ -5121,7 +5121,8 @@ void RecordSample(double t, int n)
 								P.HolidaysStartDay_SimTime++;
 							}
 						}
-						else { // on odd iterations, adjust seeding.
+						else /* if (P.ModelCalibIteration % 2 == 1) */ // on odd iterations, adjust seeding.
+						{
 							P.SeedingScaling /= pow(RatioPredictedObserved, 0.2 + 0.4 * ranf()); // include random number to prevent loops
 						}
 					}


### PR DESCRIPTION
It's all only refactoring, except this one:
```cpp
if ((P.ModelCalibIteration >= 2) && ((((RatioPredictedObserved - 1.0) <= DesiredAccuracy) && (RatioPredictedObserved >= 1)) || (((1.0 - RatioPredictedObserved) <= DesiredAccuracy) && (RatioPredictedObserved < 1))))
  P.StopCalibration = 1;
```

Based on my understanding, what it is trying to achieve is equivalent to:
```cpp
if (abs((RatioPredictedObserved - 1.0) <= DesiredAccuracy)) {
  P.StopCalibration = 1;
}
```
Edit: tests failed with that change, so I reverted it.