### PR TITLE
Allow Clang 9 To Build Master

### DIFF
--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -1353,8 +1353,6 @@ static void SusceptibleToRecovered(int cellIndex)
 
 	// assert values are non-negative
 	assert(Cells[cellIndex].S >= 0);
-	assert(Cells[cellIndex].latent >= 0);
-	assert(Cells[cellIndex].infected >= 0);
 }
 
 static void SusceptibleToLatent(int cellIndex)
@@ -1365,7 +1363,6 @@ static void SusceptibleToLatent(int cellIndex)
 
 	// assert values are non-negative
 	assert(Cells[cellIndex].S >= 0);
-	assert(Cells[cellIndex].latent >= 0);
 }
 
 
@@ -1377,7 +1374,6 @@ static void LatentToInfectious(int cellIndex)
 
 	// assert values are non-negative
 	assert(Cells[cellIndex].L >= 0);
-	assert(Cells[cellIndex].infected >= 0);
 
 }
 


### PR DESCRIPTION
#404 introduced 4x compiler errors that prevents Clang 9 from building master.

```bash
ozmorph@home:~/covid-sim/build$ clang++-9 --version
clang version 9.0.1-12 
Target: x86_64-pc-linux-gnu
Thread model: posix
```

```bash
/home/ozmorph/covid-sim/src/Update.cpp:1356:33: error: ordered comparison between pointer and zero ('int *' and 'int')
        assert(Cells[cellIndex].latent >= 0);
               ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
/home/ozmorph/covid-sim/src/Update.cpp:1357:35: error: ordered comparison between pointer and zero ('int *' and 'int')
        assert(Cells[cellIndex].infected >= 0);
               ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
/home/ozmorph/covid-sim/src/Update.cpp:1368:33: error: ordered comparison between pointer and zero ('int *' and 'int')
        assert(Cells[cellIndex].latent >= 0);
               ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
/home/ozmorph/covid-sim/src/Update.cpp:1380:35: error: ordered comparison between pointer and zero ('int *' and 'int')
        assert(Cells[cellIndex].infected >= 0);
               ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
2 warnings and 4 errors generated.
```

This patch fixes it.