### PR TITLE
Regression Test Heap Optimization: Remove Extinct Result Arrays

### DIFF
--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -89,8 +89,8 @@ Place** Places;
 AdminUnit AdUnits[MAX_ADUNITS];
 //// Time Series defs:
 //// TimeSeries is an array of type results, used to store (unsurprisingly) a time series of every quantity in results. Mostly used in RecordSample.
-//// TSMeanNE and TSVarNE are the mean and variance of non-extinct time series. TSMeanE and TSVarE are the mean and variance of extinct time series. TSMean and TSVar are pointers that point to either extinct or non-extinct.
-Results* TimeSeries, * TSMean, * TSVar, * TSMeanNE, * TSVarNE, * TSMeanE, * TSVarE; //// TimeSeries used in RecordSample, RecordInfTypes, SaveResults. TSMean and TSVar
+//// TSMean and TSVar are the mean and variance of non-extinct time series.
+Results* TimeSeries, * TSMean, * TSVar; //// TimeSeries used in RecordSample, RecordInfTypes, SaveResults. TSMean and TSVar
 Airport* Airports;
 BitmapHeader* bmh;
 //added declaration of pointer to events log: ggilani - 10/10/2014
@@ -351,15 +351,11 @@ int main(int argc, char* argv[])
 	}
 
 	P.NRactual = P.NRactNE;
-	TSMean = TSMeanNE; TSVar = TSVarNE;
 	if ((P.DoRecordInfEvents) && (P.RecordInfEventsPerRun == 0))
 	{
 		SaveEvents(output_file_base);
 	}
 	SaveSummaryResults(output_file_base + ".avNE");
-	P.NRactual = P.NRactE;
-	TSMean = TSMeanE; TSVar = TSVarE;
-	//SaveSummaryResults(output_file_base + ".avE");
 
 	Bitmap_Finalise();
 
@@ -5138,7 +5134,6 @@ void RecordSample(double t, int n, std::string const& output_file_base)
 
 	if (P.OutputBitmap >= 1)
 	{
-		TSMean = TSMeanNE; TSVar = TSVarNE;
 		CaptureBitmap	();
 		OutputBitmap	(0, output_file_base);
 	}
@@ -5263,14 +5258,17 @@ void RecordInfTypes(void)
 	nf = sizeof(Results) / sizeof(double);
 	if (!P.DoAdUnits) nf -= MAX_ADUNITS; // TODO: This still processes most of the AdUnit arrays; just not the last one
 	fprintf(stderr, "extinct=%i (%i)\n", (int) TimeSeries[P.NumSamples - 1].extinct, P.NumSamples - 1);
+	PeakHeightSum += s;
+	PeakHeightSS += s * s;
+	PeakTimeSum += t;
+	PeakTimeSS += t * t;
+
 	if (TimeSeries[P.NumSamples - 1].extinct)
 	{
-		TSMean = TSMeanE; TSVar = TSVarE; P.NRactE++;
+		P.NRactE++;
+		return;
 	}
-	else
-	{
-		TSMean = TSMeanNE; TSVar = TSVarNE; P.NRactNE++;
-	}
+	P.NRactNE++;
 	lc = -k;
 
 	// This calculates sum and sum of squares of entire TimeSeries array
@@ -5301,10 +5299,6 @@ void RecordInfTypes(void)
 		}
 		TSMean[n].t += ((double) n )* P.SampleStep;
 	}
-	PeakHeightSum += s;
-	PeakHeightSS += s * s;
-	PeakTimeSum += t;
-	PeakTimeSS += t * t;
 }
 
 

--- a/src/Model.h
+++ b/src/Model.h
@@ -304,8 +304,8 @@ extern AdminUnit AdUnits[MAX_ADUNITS];
 
 //// Time Series defs:
 //// TimeSeries is an array of type results, used to store (unsurprisingly) a time series of every quantity in results. Mostly used in RecordSample.
-//// TSMeanNE and TSVarNE are the mean and variance of non-extinct time series. TSMeanE and TSVarE are the mean and variance of extinct time series. TSMean and TSVar are pointers that point to either extinct or non-extinct.
-extern Results* TimeSeries, *TSMean, *TSVar, *TSMeanNE, *TSVarNE, *TSMeanE, *TSVarE; //// TimeSeries used in RecordSample, RecordInfTypes, SaveResults. TSMean and TSVar
+//// TSMean and TSVar are the mean and variance of non-extinct time series.
+extern Results* TimeSeries, *TSMean, *TSVar; //// TimeSeries used in RecordSample, RecordInfTypes, SaveResults. TSMean and TSVar
 
 extern Airport* Airports;
 extern Events* InfEventLog;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -221,23 +221,8 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 	SetupPopulation(density_file, out_density_file, school_file, reg_demog_file);
 
 	TimeSeries = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
-	TSMeanE = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
-	TSVarE = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
-	TSMeanNE = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
-	TSVarNE = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
-	TSMean = TSMeanE; TSVar = TSVarE;
-	///// This loops over index l twice just to reset the pointer TSMean from TSMeanE to TSMeanNE (same for TSVar).
-	int num_in_results = sizeof(Results) / sizeof(double);
-	for (l = 0; l < 2; l++)
-	{
-		for (int i = 0; i < P.NumSamples; i++)
-		{
-			double *ts_mean = (double *)&TSMean[i];
-			double *ts_var = (double *)&TSVar[i];
-			for (int j = 0; j < num_in_results; j++) ts_mean[j] = ts_var[j] = 0.0;
-		}
-		TSMean = TSMeanNE; TSVar = TSVarNE;
-	}
+	TSMean = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
+	TSVar = (Results*)Memory::xcalloc(P.NumSamples, sizeof(Results));
 
 	if (P.DoAdUnits && P.OutputAdUnitAge)
 	{
@@ -268,24 +253,18 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 			TimeSeries[Time].prevInf_age_adunit = new double* [NUM_AGE_GROUPS]();
 			TimeSeries[Time].incInf_age_adunit = new double* [NUM_AGE_GROUPS]();
 			TimeSeries[Time].cumInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanE [Time].prevInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanE [Time].incInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanE [Time].cumInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanNE[Time].prevInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanNE[Time].incInf_age_adunit = new double* [NUM_AGE_GROUPS]();
-			TSMeanNE[Time].cumInf_age_adunit = new double* [NUM_AGE_GROUPS]();
+			TSMean[Time].prevInf_age_adunit = new double* [NUM_AGE_GROUPS]();
+			TSMean[Time].incInf_age_adunit = new double* [NUM_AGE_GROUPS]();
+			TSMean[Time].cumInf_age_adunit = new double* [NUM_AGE_GROUPS]();
 
 			for (int AgeGroup = 0; AgeGroup < NUM_AGE_GROUPS; AgeGroup++)
 			{
 				TimeSeries[Time].prevInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
 				TimeSeries[Time].incInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
 				TimeSeries[Time].cumInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanE[Time].prevInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanE[Time].incInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanE[Time].cumInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanNE[Time].prevInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanNE[Time].incInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
-				TSMeanNE[Time].cumInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
+				TSMean[Time].prevInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
+				TSMean[Time].incInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
+				TSMean[Time].cumInf_age_adunit[AgeGroup] = new double[P.NumAdunits]();
 			}
 		}
 	}
@@ -612,7 +591,6 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 		fprintf(stderr, "Reset spatial R0 to 0\n");
 	}
 	fprintf(stderr, "LocalBeta = %lg\n", P.LocalBeta);
-	TSMean = TSMeanNE; TSVar = TSVarNE;
 	fprintf(stderr, "Calculated approx cell probabilities\n");
 	for (int i = 0; i < INFECT_TYPE_MASK; i++) inftype_av[i] = 0;
 	for (int i = 0; i < MAX_COUNTRIES; i++) infcountry_av[i] = infcountry_num[i] = 0;


### PR DESCRIPTION
**Objective**

Reduce RAM usage in regression tests so that GitHub Action runners can run all 4 tests without paging memory.

**Background**

The size of the `Results` struct in `Model.h` is nearly 805 KB on Clang 9 for Linux, which when accounting for an array of `P.NumSamples` (`720` in the regression tests) means that `TSMeanE` and `TSVarE` each require an allocation of around 580 MB. As a result, a single regression test will use over 1.1 GB of RAM just for these two arrays alone. When all 4 tests are ran in parallel, they consume 4.4 GB of RAM.

**Rationale**

As noted in #388, the default GitHub action runners have only 7 GB of total RAM and a 14 GB temporary storage device allocated to them. For Linux environments [the swap space is set to 4GB](https://github.com/actions/virtual-environments/pull/965) and on Windows [the swap space is most likely set to 2GB](https://github.com/mrc-ide/covid-sim/pull/388#issuecomment-646626562).

Local runs using [heaptrack](https://github.com/KDE/heaptrack) indicate that about 3.5GB is the average heap size of each run of `CovidSim`. If accounting for the fact that the US regression tests run for a fraction of the time that the UK tests do, let's assume that on average 7 GB of RAM is being used by the regression tests and a maximum of 14 GB is used. Windows Server 2019 requires [512MB of RAM to run](https://docs.microsoft.com/en-us/windows-server/get-started-19/sys-reqs-19). If 7 GB is the total amount of RAM given to the runners, this does not leave much room to the operating system itself. Therefore, I surmise that `CovidSim` is hitting paged memory for at least the first half of a `ctest -j6 -V` run.

**Solution**

This pull request removes the `TSMeanE` and `TSVarE` arrays from the code since they haven't been [used in the final output](https://github.com/mrc-ide/covid-sim/blame/8c4f0d547b5fe13cb300adcb2555fde9fc203dc4/src/CovidSim.cpp#L365) since the initial squash of commits back in April. The regression tests still pass.

**Known Concerns**

If this code is still used on the super-computers or outside of the regression tests listed on GitHub, then please close this PR and I will open a new PR that documents its use so that someone doesn't attempt to propose this change in the future.

**Alternative/Additional Solution**

The memory requirements of the `Result` arrays could also be optimized either with heap-allocated C style arrays or std::vectors  instead of static double arrays of `MAX_ADUNITS` size (which is set to `3200` but the regression tests only use 1 or 2 elements). However this would require far deeper and more extensive changes to the code base than this Pull Request.