### PR TITLE
Use guards instead of pragma once

### DIFF
--- a/covid-sim.vcxproj
+++ b/covid-sim.vcxproj
@@ -119,6 +119,7 @@
     <ClInclude Include="src\Country.h" />
     <ClInclude Include="src\Dist.h" />
     <ClInclude Include="src\Error.h" />
+    <ClInclude Include="src\IndexList.h" />
     <ClInclude Include="src\InfStat.h" />
     <ClInclude Include="src\Kernels.h" />
     <ClInclude Include="src\Memory.h" />

--- a/include/geometry/BoundingBox.h
+++ b/include/geometry/BoundingBox.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_GEOMETRY_BOUNDING_BOX_H_INCLUDED_
+#define COVIDSIM_GEOMETRY_BOUNDING_BOX_H_INCLUDED_
 
 // Local headers
 #include "Vector2.h"
@@ -191,3 +192,5 @@ namespace Geometry {
     }
   };
 }
+
+#endif

--- a/include/geometry/Size.h
+++ b/include/geometry/Size.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_GEOMETRY_SIZE_H_INCLUDED_
+#define COVIDSIM_GEOMETRY_SIZE_H_INCLUDED_
 
 #include <cmath>
 #include "Vector2.h"
@@ -110,3 +111,5 @@ namespace Geometry {
 		return Vector2<U>((U)this->width, (U)this->height);
 	}
 }
+
+#endif

--- a/include/geometry/Vector2.h
+++ b/include/geometry/Vector2.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef COVIDSIM_GEOMETRY_VECTOR2_H_INCLUDED_
+#define COVIDSIM_GEOMETRY_VECTOR2_H_INCLUDED_
+
 
 #include <cmath>
 
@@ -150,3 +152,5 @@ namespace Geometry {
 	Vector2d operator-(const Vector2d &left, const Vector2i &right);
 	Vector2d operator-(const Vector2i &left, const Vector2d &right);
 }
+
+#endif

--- a/src/Direction.hpp
+++ b/src/Direction.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_DIRECTION_HPP_INCLUDED_
+#define COVIDSIM_DIRECTION_HPP_INCLUDED_
 
 enum Direction {
 	Right = 0,
@@ -8,3 +9,5 @@ enum Direction {
 };
 
 Direction rotate_left(Direction direction);
+
+#endif

--- a/src/IndexList.h
+++ b/src/IndexList.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_INDEXLIST_H_INCLUDED_
+#define COVIDSIM_INDEXLIST_H_INCLUDED_
 
 /**
  * @brief Used for computing spatial interactions more efficiently.
@@ -8,3 +9,4 @@ struct IndexList
 	int id;
 	float prob;
 };
+#endif

--- a/src/InverseCdf.h
+++ b/src/InverseCdf.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_INVERSE_CDF_H_INCLUDED_
+#define COVIDSIM_INVERSE_CDF_H_INCLUDED_
 
 #include "Constants.h"
 
@@ -29,6 +30,4 @@ public:
 	}
 };
 
-
-
-
+#endif

--- a/src/MicroCellPosition.hpp
+++ b/src/MicroCellPosition.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_MICRO_CELL_POSITION_HPP_INCLUDED_
+#define COVIDSIM_MICRO_CELL_POSITION_HPP_INCLUDED_
 
 #include "Direction.hpp"
 #include "Error.h"
@@ -20,3 +21,5 @@ struct MicroCellPosition
 		return *this;
 	}
 };
+
+#endif

--- a/src/Models/Cell.h
+++ b/src/Models/Cell.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_MODELS_CELL_H_INCLUDED_
+#define COVIDSIM_MODELS_CELL_H_INCLUDED_
 
 /**
  * @brief Holds microcells.
@@ -15,3 +16,5 @@ struct Cell
 	float tot_prob, *cum_trans, *max_trans;
 	short int CurInterv[MAX_INTERVENTION_TYPES];
 };
+
+#endif

--- a/src/Models/Household.h
+++ b/src/Models/Household.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_MODELS_HOUSEHOLD_H_INCLUDED_
+#define COVIDSIM_MODELS_HOUSEHOLD_H_INCLUDED_
 
 #include "geometry/Vector2.h"
 
@@ -9,3 +10,5 @@ struct Household
 	unsigned short int nhr;
 	Geometry::Vector2<float> loc;
 };
+
+#endif

--- a/src/Models/Microcell.h
+++ b/src/Models/Microcell.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_MODELS_MICRO_CELL_H_INCLUDED_
+#define COVIDSIM_MODELS_MICRO_CELL_H_INCLUDED_
 
 #include "../IndexList.h"
 
@@ -27,3 +28,5 @@ struct Microcell
 	unsigned short int vacc_start_time;
 	IndexList* AirportList;
 };
+
+#endif

--- a/src/Models/Person.h
+++ b/src/Models/Person.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COVIDSIM_MODELS_PERSON_H_INCLUDED_
+#define COVIDSIM_MODELS_PERSON_H_INCLUDED_
 
 #include <cstdint>
 #include <limits>
@@ -57,3 +58,5 @@ struct PersonQuarantine
 	// because it conflicts with the max() preprocessor macro in MSVC builds
 	PersonQuarantine() : comply(2), start_time((std::numeric_limits<uint16_t>::max)()-1) {} 
 };
+
+#endif


### PR DESCRIPTION
With apologies to those who really prefer #pragma once, for consistency and to resolve a fairly uninteresting discussion, we're employing "code-owner's perogative" and saying we'll stay with header guards rather than #pragma once. While the "risks" of #pragma once are miniscule, there are no risks at all with the guards, other than preference, so for the sake of consistency, that's the way we'll go.

I appreciate that's not everyone's favourite thing, but it's a couple of lines per header - not important or prominent things, and there are many other more worthy things to focus in...