### PR TITLE
Basic set only works for this and subdirectories so set to the cache …

### DIFF
--- a/include/geometry/CMakeLists.txt
+++ b/include/geometry/CMakeLists.txt
@@ -1,1 +1,5 @@
-set(GEOMETRY_HDR_FILES Size.h Vector2.h BoundingBox.h)
+set(GEOMETRY_HDR_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Size.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Vector2.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/BoundingBox.h
+    CACHE INTERNAL "Headers" FORCE)


### PR DESCRIPTION
…instead.

i.e. Fix the bug I put into the build system whereby changes to the geometry headers are (probably) ignored.
Using a variable in CMake that hasn't been set within the same scope just returns an empty value...