### PR TITLE
Fix minor warnings

### DIFF
--- a/include/geometry/Size.h
+++ b/include/geometry/Size.h
@@ -49,7 +49,7 @@ namespace CovidSim { namespace Geometry {
 	Size<T>::Size(const Vector2<T> &dimensions) : width(dimensions.x), height(dimensions.y) {}
 
 	template<class T>
-	Size<T>::Size(T width, T height) : width(width), height(height) {}
+	Size<T>::Size(T _width, T _height) : width(_width), height(_height) {}
 
 	template<class T>
 	T Size<T>::area() const {

--- a/include/geometry/Vector2.h
+++ b/include/geometry/Vector2.h
@@ -12,7 +12,7 @@ namespace CovidSim { namespace Geometry {
 
 		DiagonalMatrix2() : x(), y() {}
 
-		DiagonalMatrix2(T x, T y) : x(x), y(y) {}
+		DiagonalMatrix2(T _x, T _y) : x(_x), y(_y) {}
 
 		template<class U>
 		explicit operator DiagonalMatrix2<U>() const {
@@ -27,7 +27,7 @@ namespace CovidSim { namespace Geometry {
 
 		Vector2();
 
-		Vector2(T x, T y);
+		Vector2(T _x, T _y);
 
 		T length() const;
 
@@ -64,7 +64,7 @@ namespace CovidSim { namespace Geometry {
 	Vector2<T>::Vector2() : x(), y() {}
 
 	template<class T>
-	Vector2<T>::Vector2(T x, T y) : x(x), y(y) {}
+	Vector2<T>::Vector2(T _x, T _y) : x(_x), y(_y) {}
 
 	template<class T>
 	T Vector2<T>::length() const {

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -31,7 +31,7 @@ static unsigned char* bmf, *bmPixels, *bmp;
 void CaptureBitmap()
 {
 	int x, y, f, mi;
-	unsigned j;
+	unsigned int j;
 	static double logMaxPop;
 	static int fst = 1;
 	double prev;
@@ -49,7 +49,7 @@ void CaptureBitmap()
 			if ((x >= 0) && (x < P.b.width) && (y >= 0) && (y < P.b.height))
 			{
 				j = y * bmh->width + x;
-				if ((j < bmh->imagesize) && (j >= 0))
+				if (j < bmh->imagesize)
 				{
 					bmPopulation[j]++;
 					if (bmPopulation[j] > maxPop) maxPop = bmPopulation[j];
@@ -74,7 +74,7 @@ void CaptureBitmap()
 					if ((x >= 0) && (x < P.b.width) && (y >= 0) && (y < P.b.height))
 					{
 						j = y * bmh->width + x;
-						if ((j < bmh->imagesize) && (j >= 0)) bmPopulation[j] = -1;
+						if (j < bmh->imagesize) bmPopulation[j] = -1;
 					}
 				}
 			}
@@ -255,7 +255,7 @@ void InitBMHead(std::string const& out_file_base)
 #ifdef _WIN32
 	if (P.BitmapFormat == BitmapFormats::PNG)
 	{
-	  bmpdib = CreateDIBSection(GetDC(NULL), (BITMAPINFO*)bmp, DIB_RGB_COLORS, (void**)&bmPixels, NULL, NULL);
+	  bmpdib = CreateDIBSection(GetDC(NULL), (BITMAPINFO*)bmp, DIB_RGB_COLORS, (void**)&bmPixels, NULL, 0);
 	  Gdiplus::GdiplusStartupInput gdiplusStartupInput;
 	  Gdiplus::GdiplusStartup(&m_gdiplusToken, &gdiplusStartupInput, NULL);
 
@@ -266,14 +266,16 @@ void InitBMHead(std::string const& out_file_base)
 	  Gdiplus::GetImageEncodersSize(&num, &size);
 	  pImageCodecInfo = (Gdiplus::ImageCodecInfo*)Memory::xcalloc(1, size);
 	  Gdiplus::GetImageEncoders(num, size, pImageCodecInfo);
-	  for (UINT j = 0; j < num; ++j) {
+	  for (UINT j2 = 0; j2 < num; ++j2) {
 	    // Visual Studio Analyze incorrectly reports this because it doesn't understand Gdiplus::GetImageEncodersSize()
 	    // warning C6385: Reading invalid data from 'pImageCodecInfo':  the readable size is 'size' bytes, but '208' bytes may be read.
+#ifdef _MSC_VER
 #pragma warning( suppress: 6385 )
-	    const WCHAR* type = pImageCodecInfo[j].MimeType;
+#endif
+	    const WCHAR* type = pImageCodecInfo[j2].MimeType;
 	    if (wcscmp(type, L"image/png") == 0) {
-	      encoderClsid = pImageCodecInfo[j].Clsid;
-	      j = num;
+	      encoderClsid = pImageCodecInfo[j2].Clsid;
+	      j2 = num;
 	    }
 	  }
 	  free(pImageCodecInfo);

--- a/src/Bitmap.h
+++ b/src/Bitmap.h
@@ -12,7 +12,6 @@
 
 #define STRICT
 #ifdef _WIN32
-#define _WIN32_WINNT 0x0400
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <vfw.h>

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -107,7 +107,7 @@ void CmdLineArgs::add_string_option(std::string const& option, StringParserFn fu
 	add_custom_option(option, std::bind(func, std::placeholders::_1, std::ref(output)), doc);
 }
 
-void CmdLineArgs::parse(int argc, char* argv[], Param& P)
+void CmdLineArgs::parse(int argc, char* argv[], Param& params)
 {
 	// Detect if the user wants to print out the full help output
 	if (argc >= 2)
@@ -127,10 +127,10 @@ void CmdLineArgs::parse(int argc, char* argv[], Param& P)
 
 	// Get seeds.
 	int i = argc - 4;
-	parse_integer(argv[i], P.setupSeed1);
-	parse_integer(argv[i+1], P.setupSeed2);
-	parse_integer(argv[i+2], P.runSeed1);
-	parse_integer(argv[i+3], P.runSeed2);
+	parse_integer(argv[i], params.setupSeed1);
+	parse_integer(argv[i+1], params.setupSeed2);
+	parse_integer(argv[i+2], params.runSeed1);
+	parse_integer(argv[i+3], params.runSeed2);
 
 	for (i = 1; i < argc - 4; i++)
 	{

--- a/src/CalcInfSusc.cpp
+++ b/src/CalcInfSusc.cpp
@@ -51,26 +51,26 @@ double CalcPersonInf(int j, unsigned short int ts)
 
 //// Susceptibility functions (House, Place, Spatial, Person). Similarly, idea is that in addition to a person's personal susceptibility, they have separate "susceptibilities" for their house, place and on other cells (spatial)
 //// These functions consider two people. A person has a susceptibility TO ANOTHER PERSON/infector. Slightly different therefore than infectiousness functions.
-double CalcHouseSusc(int ai, unsigned short int ts, int infector, int tn)
+double CalcHouseSusc(int ai, unsigned short int ts, int infector)
 {
-	return CalcPersonSusc(ai, ts, infector, tn)
+	return CalcPersonSusc(ai, ts, infector)
 		* ((Mcells[Hosts[ai].mcell].socdist == 2) ? ((Hosts[ai].esocdist_comply) ? P.EnhancedSocDistHouseholdEffectCurrent : P.SocDistHouseholdEffectCurrent) : 1.0)
 		* ((Hosts[ai].digitalContactTraced==1) ? P.DCTCaseIsolationHouseEffectiveness : 1.0)
 		* ((Hosts[ai].care_home_resident) ? P.CareHomeResidentHouseholdScaling : 1.0);
 }
-double CalcPlaceSusc(int ai, int k, unsigned short int ts, int infector, int tn)
+double CalcPlaceSusc(int ai, int k, unsigned short int ts)
 {
 	return		((HOST_QUARANTINED(ai) && (!Hosts[ai].care_home_resident) && (Hosts[ai].digitalContactTraced != 1)) ? P.HQuarantinePlaceEffect[k] : 1.0)
 		* ((Mcells[Hosts[ai].mcell].socdist == 2) ? ((Hosts[ai].esocdist_comply) ? P.EnhancedSocDistPlaceEffectCurrent[k] : P.SocDistPlaceEffectCurrent[k]) : 1.0)
 		* ((Hosts[ai].digitalContactTraced==1) ? P.DCTCaseIsolationEffectiveness : 1.0);
 }
-double CalcSpatialSusc(int ai, unsigned short int ts, int infector, int tn)
+double CalcSpatialSusc(int ai, unsigned short int ts)
 {
 	return	 ((HOST_QUARANTINED(ai) && (!Hosts[ai].care_home_resident) && (Hosts[ai].digitalContactTraced != 1)) ? P.HQuarantineSpatialEffect : 1.0)
 		* ((Mcells[Hosts[ai].mcell].socdist == 2) ? ((Hosts[ai].esocdist_comply) ? P.EnhancedSocDistSpatialEffectCurrent : P.SocDistSpatialEffectCurrent) : 1.0)
 		* ((Hosts[ai].digitalContactTraced == 1) ? P.DCTCaseIsolationEffectiveness : 1.0);
 }
-double CalcPersonSusc(int ai, unsigned short int ts, int infector, int tn)
+double CalcPersonSusc(int ai, unsigned short int ts, int infector)
 {
 	return		P.WAIFW_Matrix[HOST_AGE_GROUP(ai)][HOST_AGE_GROUP(infector)]
 		* P.AgeSusceptibility[HOST_AGE_GROUP(ai)] * Hosts[ai].susc

--- a/src/CalcInfSusc.h
+++ b/src/CalcInfSusc.h
@@ -5,9 +5,9 @@ double CalcHouseInf(int, unsigned short int);
 double CalcPlaceInf(int, int, unsigned short int);
 double CalcSpatialInf(int, unsigned short int);
 double CalcPersonInf(int, unsigned short int);
-double CalcHouseSusc(int, unsigned short int, int, int);
-double CalcPlaceSusc(int, int, unsigned short int, int, int);
-double CalcSpatialSusc(int, unsigned short int, int, int);
-double CalcPersonSusc(int, unsigned short int, int, int);
+double CalcHouseSusc(int, unsigned short int, int);
+double CalcPlaceSusc(int, int, unsigned short int);
+double CalcSpatialSusc(int, unsigned short int);
+double CalcPersonSusc(int, unsigned short int, int);
 
 #endif // COVIDSIM_CALCINFSUSC_

--- a/src/CovidSim.h
+++ b/src/CovidSim.h
@@ -25,4 +25,11 @@
 #include "Country.h"
 #include "Constants.h"
 
+int ChooseTriggerVariableAndValue(int AdUnit);
+double ChooseThreshold(int AdUnit, double WhichThreshold);
+void UpdateEfficaciesAndComplianceProportions(double t);
+void RecordAdminAgeBreakdowns(int t_int);
+void RecordQuarNotInfected(int n, unsigned short int ts);
+bool readString(const char* SItemName, FILE* dat, char *buf);
+
 #endif // COVIDSIM_COVIDSIM_H_INCLUDED_

--- a/src/Dist.h
+++ b/src/Dist.h
@@ -13,5 +13,6 @@ double dist2_cc(Cell*, Cell*);
 double dist2_cc_min(Cell*, Cell*);
 double dist2_mm(Microcell*, Microcell*);
 double dist2_raw(double, double, double, double);
+double periodic_xy(double x, double y);
 
 #endif // COVIDSIM_DIST_H_INCLUDED_

--- a/src/Rand.cpp
+++ b/src/Rand.cpp
@@ -509,9 +509,6 @@ TYPE OF ISEED SHOULD BE DICTATED BY THE UNIFORM GENERATOR
 **********************************************************************
 *****DETERMINE APPROPRIATE ALGORITHM AND WHETHER SETUP IS NECESSARY
 */
-/* JJV changed initial values to ridiculous values */
-	double psave = -1.0E37;
-	int32_t nsave = -214748365;
 	int32_t ignbin_mt, i, ix, ix1, k, m, mp, T1;
 	double al, alv, amaxp, c, f, f1, f2, ffm, fm, g, p, p1, p2, p3, p4, q, qn, r, u, v, w, w2, x, x1,
 		x2, xl, xll, xlr, xm, xnp, xnpq, xr, ynorm, z, z2;
@@ -522,7 +519,7 @@ TYPE OF ISEED SHOULD BE DICTATED BY THE UNIFORM GENERATOR
 	*/
 	if (pp < 0.0) ERR_CRITICAL("PP < 0.0 in IGNBIN");
 	if (pp > 1.0) ERR_CRITICAL("PP > 1.0 in IGNBIN");
-	psave = pp;
+	double psave = pp;
 	p = std::min(psave, 1.0 - psave);
 	q = 1.0 - p;
 
@@ -531,7 +528,7 @@ TYPE OF ISEED SHOULD BE DICTATED BY THE UNIFORM GENERATOR
 	*/
 	if (n < 0) ERR_CRITICAL("N < 0 in IGNBIN");
 	xnp = n * p;
-	nsave = n;
+
 	if (xnp < 30.0) goto S140;
 	ffm = xnp + p;
 	m = (int32_t)ffm;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <ctime>
 #include <vector>
+#define __STDC_FORMAT_MACROS 1
 
 #include "BinIO.h"
 #include "Error.h"
@@ -32,7 +33,7 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 {
 	int l, m, j2, l2, m2;
 	unsigned int rn;
-	double t, s, s2, t2;
+	double t, s, s2;
 	char buf[2048];
 	FILE* dat;
 
@@ -69,7 +70,7 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 			rewind(dat);
 			BinFileBuf = (void*)Memory::xcalloc(P.BinFileLen, sizeof(BinFile));
 			BF = (BinFile*)BinFileBuf;
-			int index = 0;
+			unsigned int index = 0;
 			while(fgets(buf, sizeof(buf), dat) != NULL)
 			{
 				int i2;
@@ -211,7 +212,6 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 	fprintf(stderr, "Coords xmcell=%lg m   ymcell = %lg m\n",
 		sqrt(dist2_raw(P.in_degrees_.width / 2, P.in_degrees_.height / 2, P.in_degrees_.width / 2 + P.in_microcells_.width, P.in_degrees_.height / 2)),
 		sqrt(dist2_raw(P.in_degrees_.width / 2, P.in_degrees_.height / 2, P.in_degrees_.width / 2, P.in_degrees_.height / 2 + P.in_microcells_.height)));
-	t2 = 0.0;
 
 	SetupPopulation(density_file, out_density_file, school_file, reg_demog_file);
 
@@ -1447,7 +1447,6 @@ void SetupPopulation(std::string const& density_file, std::string const& out_den
 	{
 		fprintf(stderr, "Configuring places...\n");
 
-		FILE* stderr_shared = stderr;
 #pragma omp parallel for private(j2,j,t,m,s,x,y,xh,yh) schedule(static,1) default(none) \
 			shared(P, Hosts, Places, PropPlaces, Mcells, maxd, last_i, mcell_country, stderr_shared)
 		for (int tn = 0; tn < P.NumThreads; tn++)
@@ -1916,7 +1915,7 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 
 void AssignPeopleToPlaces()
 {
-	int i2, j, j2, k, k2, l, m, tp, f, f2, f3, f4, ic, a, cnt, ca, nt, nn;
+	int i2, j, j2, k, k2, l, m, tp, f, f2, f3, f4, ic, a, cnt, ca, nn;
 	int* PeopleArray;
 	int* NearestPlaces[MAX_NUM_THREADS];
 	double s, t, *NearestPlacesProb[MAX_NUM_THREADS];
@@ -2173,7 +2172,6 @@ void AssignPeopleToPlaces()
 				ca = 0;
 				fprintf(stderr, "Allocating people to place type %i\n", tp);
 				a = cnt;
-				nt = P.NumThreads;
 				nn = P.PlaceTypeNearestNeighb[tp];
 				if (P.PlaceTypeNearestNeighb[tp] > 0)
 				{

--- a/src/Sweep.cpp
+++ b/src/Sweep.cpp
@@ -391,7 +391,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 						{
 							if ((Hosts[i3].inf == InfStat_Susceptible) && (!Hosts[i3].Travelling)) //// if people in household uninfected/susceptible and not travelling
 							{
-								s = s3 * CalcHouseSusc(i3, ts, ci, tn);		//// FOI ( = infectiousness x susceptibility) from person ci/si on fellow household member i3
+								s = s3 * CalcHouseSusc(i3, ts, ci);		//// FOI ( = infectiousness x susceptibility) from person ci/si on fellow household member i3
 								
 								// Force of Infection (s) > random value between 0 and 1
 								if (ranf_mt(tn) < s) 
@@ -520,7 +520,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 										int i3 = Places[k][l].members[Places[k][l].group_start[i2] + SamplingQueue[tn][m]];
 										// calculate place susceptbility based on infectee (i3), place type (k), timestep (ts)
 										// cell (ci) and thread number (tn)
-										s = CalcPlaceSusc(i3, k, ts, ci, tn);
+										s = CalcPlaceSusc(i3, k, ts);
 
 										// allow care home residents to mix more intensely in "groups" (i.e. individual homes) than staff do - to allow for PPE/environmental contamination.
 										if ((k==P.CareHomePlaceType)&&((!Hosts[ci].care_home_resident)||(!Hosts[i3].care_home_resident))) s *= P.CareHomeWorkerGroupScaling;
@@ -553,7 +553,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 										{
 											Microcell* mt = Mcells + Hosts[i3].mcell;
 											//downscale s if it has been scaled up do to digital contact tracing
-											s *= CalcPersonSusc(i3, ts, ci, tn)*s4/s4_scaled;
+											s *= CalcPersonSusc(i3, ts, ci)*s4/s4_scaled;
 
 											// if blanket movement restrictions are in place
 											if (bm)
@@ -616,7 +616,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 										// select potential infectee from sampling queue
 										int i3 = Places[k][l].members[SamplingQueue[tn][m]];
 										// calculate place susceptibility s
-										s = CalcPlaceSusc(i3, k, ts, ci, tn);
+										s = CalcPlaceSusc(i3, k, ts);
 										// use group structure to model multiple care homes with shared staff - in which case residents of one "group" don't mix with those in another, only staff do.
 										if ((Hosts[ci].care_home_resident) && (Hosts[i3].care_home_resident) && (Hosts[ci].PlaceGroupLinks[k]!= Hosts[i3].PlaceGroupLinks[k])) s *= P.CareHomeResidentPlaceScaling;
 										// allow care home staff to have lowere contacts in care homes - to allow for PPE/environmental contamination.
@@ -656,7 +656,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 											Microcell* mt = Mcells + Hosts[i3].mcell;
 
 											//if doing digital contact tracing, scale down susceptibility here
-											s*= CalcPersonSusc(i3, ts, ci, tn)*s3/s3_scaled;
+											s*= CalcPersonSusc(i3, ts, ci)*s3/s3_scaled;
 											// if blanket movement restrictions are in place
 											if (bm)
 											{
@@ -855,7 +855,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 								Microcell* mi = Mcells + si->mcell;
 								// pick microcell of infectee (mt)
 								Microcell* mt = Mcells + Hosts[i3].mcell;
-								s = CalcSpatialSusc(i3, ts, ci, tn);
+								s = CalcSpatialSusc(i3, ts);
 								// Care home residents may have fewer contacts
 								if ((Hosts[i3].care_home_resident) || (Hosts[ci].care_home_resident)) s *= P.CareHomeResidentSpatialScaling;
 								//so this person is a contact - but might not be infected. if we are doing digital contact tracing, we want to add the person to the contacts list, if both are users
@@ -886,7 +886,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 							
 								if (m < ct->S)  // only bother trying to infect susceptible people
 								{
-									s *= CalcPersonSusc(i3, ts, ci, tn);
+									s *= CalcPersonSusc(i3, ts, ci);
 									if (bm)
 									{
 										if ((dist2_raw(Households[si->hh].loc.x, Households[si->hh].loc.y,
@@ -949,7 +949,7 @@ void InfectSweep(double t, int run) //added run number as argument in order to r
 	}
 }
 
-void IncubRecoverySweep(double t, int run)
+void IncubRecoverySweep(double t)
 {
 	double ht;
 	unsigned short int ts; //// this timestep
@@ -985,14 +985,14 @@ void IncubRecoverySweep(double t, int run)
 			}
 		}
 
-#pragma omp parallel for schedule(static,1) default(none) shared(t, run, P, CellLookup, Hosts, AdUnits, Mcells, StateT, ts)
+#pragma omp parallel for schedule(static,1) default(none) shared(t, P, CellLookup, Hosts, AdUnits, Mcells, StateT, ts)
 	for (int tn = 0; tn < P.NumThreads; tn++)	//// loop over threads
 		for (int b = tn; b < P.NCP; b += P.NumThreads)	//// loop/step over populated cells
 		{
 			Cell* c = CellLookup[b]; //// find (pointer-to) cell.
 			for (int j = ((int)c->L - 1); j >= 0; j--) //// loop backwards over latently infected people, hence it starts from L - 1 and goes to zero. Runs backwards because of pointer swapping?
 				if (ts >= Hosts[c->latent[j]].latent_time) //// if now after time at which person became infectious (latent_time a slight misnomer).
-					DoIncub(c->latent[j], ts, tn, run); //// move infected person from latently infected (L) to infectious (I), but not symptomatic
+					DoIncub(c->latent[j], ts, tn); //// move infected person from latently infected (L) to infectious (I), but not symptomatic
 			//StateT[tn].n_queue[0] = StateT[tn].n_queue[1] = 0;
 			for (int j = c->I - 1; j >= 0; j--) ///// loop backwards over Infectious people. Runs backwards because of pointer swapping?
 			{
@@ -1024,15 +1024,15 @@ void IncubRecoverySweep(double t, int run)
 				{
 					if (!si->to_die) //// if person si recovers and this timestep is after they've recovered
 					{
-						DoRecover(ci, tn, run);
+						DoRecover(ci, tn);
 						//StateT[tn].inf_queue[0][StateT[tn].n_queue[0]++] = ci; //// add them to end of 0th thread of inf queue. Don't get why 0 here.
 					}
 					else /// if they die and this timestep is after they've died.
 					{
 						if (HOST_TREATED(ci) && (ranf_mt(tn) < P.TreatDeathDrop))
-							DoRecover(ci, tn, run);
+							DoRecover(ci, tn);
 						else
-							DoDeath(ci, tn, run);
+							DoDeath(ci, tn);
 					}
 
 					//once host recovers, will no longer make contacts for contact tracing - if we are doing contact tracing and case was infectious when contact tracing was active, increment state vector
@@ -1712,7 +1712,7 @@ int TreatSweep(double t)
 							for (int j2 = 0; j2 < P.PlaceTypeNum; j2++)
 								if (j2 != P.HotelPlaceType)
 									for (int i2 = 0; i2 < Mcells[b].np[j2]; i2++)
-										DoPlaceOpen(j2, Mcells[b].places[j2][i2], ts, tn);
+										DoPlaceOpen(j2, Mcells[b].places[j2][i2], ts);
 						}
 					}
 

--- a/src/Sweep.h
+++ b/src/Sweep.h
@@ -4,7 +4,7 @@
 void TravelReturnSweep(double);
 void TravelDepartSweep(double);
 void InfectSweep(double, int); //added int as argument to InfectSweep to record run number: ggilani - 15/10/14
-void IncubRecoverySweep(double, int); //added int as argument to record run number: ggilani - 15/10/14
+void IncubRecoverySweep(double); 
 int TreatSweep(double);
 //void HospitalSweep(double); //added hospital sweep function: ggilani - 10/11/14
 void DigitalContactTracingSweep(double); // added function to update contact tracing number

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -188,9 +188,9 @@ void DoInfect(int ai, double t, int tn, int run) // Change person from susceptib
 		}
 		if ((t > 0) && (P.DoOneGen))
 		{
-			DoIncub(ai, ts, tn, run);
+			DoIncub(ai, ts, tn);
 			DoCase(ai, t, ts, tn);
-			DoRecover(ai, tn, run);
+			DoRecover(ai, tn);
 		}
 	}
 }
@@ -349,6 +349,13 @@ void DoDeath_FromCriticalorSARIorILI(int ai, int tn)
 				ToDeathILI(tn, a->mcell, ai);
 				a->Severity_Current = Severity::Dead;
 				break;
+
+			case Severity::Asymptomatic:
+			case Severity::Dead:
+			case Severity::Mild:
+			case Severity::Recovered:
+			case Severity::RecoveringFromCritical:
+			  break;
 		}
 	}
 }
@@ -387,11 +394,18 @@ void DoRecover_FromSeverity(int ai, int tn)
 					FromCritRecov(tn, a->mcell, ai);
 					a->Severity_Current = Severity::Recovered;
 					break;
+
+				case Severity::Asymptomatic:
+				case Severity::Critical:
+				case Severity::Dead:
+				case Severity::Recovered:
+				  break;
+				
 			}
 		}
 }
 
-void DoIncub(int ai, unsigned short int ts, int tn, int run)
+void DoIncub(int ai, unsigned short int ts, int tn)
 {
 	Person* a;
 	double q;
@@ -882,7 +896,7 @@ void DoFalseCase(int ai, double t, unsigned short int ts, int tn)
 	StateT[tn].cumFC++;
 }
 
-void DoRecover(int ai, int tn, int run)
+void DoRecover(int ai, int tn)
 {
 	int i, j;
 	Person* a;
@@ -910,13 +924,13 @@ void DoRecover(int ai, int tn, int run)
 				Vector2i pixel((Households[a->hh].loc * P.scale) - P.bmin);
 				if (P.b.contains(pixel))
 				{
-					unsigned j = pixel.y * bmh->width + pixel.x;
-					if (j < bmh->imagesize)
+					unsigned int j2 = pixel.y * bmh->width + pixel.x;
+					if (j2 < bmh->imagesize)
 					{
 #pragma omp atomic
-						bmRecovered[j]++;
+						bmRecovered[j2]++;
 #pragma omp atomic
-						bmInfected[j]--;
+						bmInfected[j2]--;
 					}
 				}
 			}
@@ -926,7 +940,7 @@ void DoRecover(int ai, int tn, int run)
 	//fprintf(stderr, "\n ### %i %i  \n", ai, a->inf);
 }
 
-void DoDeath(int ai, int tn, int run)
+void DoDeath(int ai, int tn)
 {
 	int i;
 	Person* a = Hosts + ai;
@@ -1223,7 +1237,7 @@ void UpdateHostClosure() {
 	}
 }
 
-void DoPlaceOpen(int i, int j, unsigned short int ts, int tn)
+void DoPlaceOpen(int i, int j, unsigned short int ts)
 {
 	int k, ai, j1, j2, l, f;
 

--- a/src/Update.h
+++ b/src/Update.h
@@ -3,15 +3,15 @@
 
 void DoImmune(int);
 void DoInfect(int, double, int, int); //added int as argument to InfectSweep to record run number: ggilani - 15/10/14
-void DoIncub(int, unsigned short int, int, int); //added int as argument to record run number: ggilani - 23/10/14
+void DoIncub(int, unsigned short int, int); //added int as argument to record run number: ggilani - 23/10/14
 void DoDetectedCase(int, double, unsigned short int, int);
 void DoCase(int, double, unsigned short int, int);
 void DoFalseCase(int, double, unsigned short int, int);
-void DoRecover(int, int, int); //added int as argument to record run number: ggilani - 23/10/14. Added thread number to record Severity categories in StateT.
-void DoDeath(int, int, int); //added int as argument to record run number: ggilani - 23/10/14
+void DoRecover(int, int); // Added thread number to record Severity categories in StateT.
+void DoDeath(int, int); 
 void DoPlaceClose(int, int, unsigned short int, int, int);
 void UpdateHostClosure();
-void DoPlaceOpen(int, int, unsigned short int, int);
+void DoPlaceOpen(int, int, unsigned short int);
 void DoTreatCase(int, unsigned short int, int);
 void DoProph(int, unsigned short int, int);
 void DoProphNoDelay(int, unsigned short int, int, int);
@@ -24,5 +24,6 @@ void DoCritical(int, int);
 void DoRecoveringFromCritical(int, int);
 void DoRecover_FromSeverity(int, int);
 void DoDeath_FromCriticalorSARIorILI(int, int);
+void DoILI(int ai, int tn);
 
 #endif // COVIDSIM_UPDATE_H_INCLUDED_


### PR DESCRIPTION
This PR clears all warnings shown when compiling with g++ with these flags:
-Wall -Wextra -Wwrite-strings -Wmissing-declarations -Wshadow