### PR TITLE
Add documentation for writing UnitTests

### DIFF
--- a/docs/writing-google-tests.md
+++ b/docs/writing-google-tests.md
@@ -68,7 +68,7 @@ To test behaviours of particular CovidSim functions, include the appropriate hea
 For example if testing functions in SetupModel.cpp, you would `#include "SetupModel.h"` in your sources and then have your CMakeLists.txt entry for the test look like:
 
 ```
-add_unit_tests(TARGET test-basic SOURCES test-basic.cpp $CMAKE_SOURCE_DIR/src/SetupModel.cpp)
+add_unit_tests(TARGET test-basic SOURCES test-basic.cpp ${CMAKE_SOURCE_DIR}/src/SetupModel.cpp)
 ```
 
 Note: The limitation here is that we cannot test functions in CovidSim.cpp because that has a `main()` function which will get the test framework confused.  The solution here is to move the functions under test out of CovidSim.cpp

--- a/docs/writing-google-tests.md
+++ b/docs/writing-google-tests.md
@@ -1,0 +1,89 @@
+# Writing Google Test tests for CovidSim
+
+The unit test framework chosen is called Google Test and is a fairly widely
+used framework.
+
+The basic structure for adding a test involves creating a test executable, and
+adding it to the list of unit tests in the appropriate CMakeLists.txt
+
+## Overview
+
+### Initial Test
+
+Start with a basic test file.  Somewhere in the `unit_tests` tree create a test
+source file.  In this example we'll use `test-basic.cpp` as an example.
+
+In the test file put the basic scaffolding needed to use GoogleTest:
+
+```c++
+#include <gtest/gtest.h>
+
+TEST(CovidSimBasicTest, BasicTest)
+{
+    ASSERT_EQ(1, 1);
+}
+```
+
+### Add to build system.
+
+At the bottom of `./unit_tests/CMakeLists.txt` (or an appropriate CMakeLists.txt in a subdirectory) add a call to create the test:
+
+```
+add_unit_tests(TARGET test-basic SOURCES test-basic.cpp)
+```
+
+Now rerun cmake and run the tests.  From the command line, something like:
+
+```sh
+cd <build directory>
+cmake . # Update config to know about new test executable
+cmake --build . # Build CovidSim & Tests
+ctest # Run all tests
+```
+
+See the (build documentation)[./build.md] for further details.
+
+### Writing actual tests
+
+Tests go in the test source file (`test-basic.cpp` in this example).
+
+For full documentation on GoogleTest
+(read their docs)[https://github.com/google/googletest/blob/v1.10.x/googletest/docs/primer.md].
+
+Note that we use v0.10 of Google Test and the trunk development has moved on with changing some nomenculture, so check you are reading the correct docs version.
+
+However, in summary tests look like:
+
+```c++
+TEST(<TESTSUITENAME>, <TEST>)
+{
+    // Do stuff - set code up, call functions, etc.
+    ASSERT_EQ(X, Y); /* Checks X == Y, for everything except C-Style strings */
+    ASSERT_STREQ(A, B); /* Checks that the C-Style strings A & B are the same. */
+}
+```
+
+To test behaviours of particular CovidSim functions, include the appropriate header, and then add the source file to the SOURCES list for that test in CMakeLists.txt.
+
+For example if testing functions in SetupModel.cpp, you would `#include "SetupModel.h"` in your sources and then have your CMakeLists.txt entry for the test look like:
+
+```
+add_unit_tests(TARGET test-basic SOURCES test-basic.cpp $CMAKE_SOURCE_DIR/src/SetupModel.cpp)
+```
+
+Note: The limitation here is that we cannot test functions in CovidSim.cpp because that has a `main()` function which will get the test framework confused.  The solution here is to move the functions under test out of CovidSim.cpp
+
+Note: You have to specify a full path to the SetupModel.cpp code.
+
+Note: That CMake uses `/` as a directory separator internally even on Windows.
+
+### Debugging Unit Tests
+
+The unit tests are stand alone programs that can be run by hand.  For example on UNIX.
+
+```sh
+cd build/unit-tests
+./test-basic
+```
+
+The GoogleTest framework provides some extra command line options pass `--help` to see them.  Otherwise use your standard debugger to test the executable.

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_policy(SET CMP0079 NEW)
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -17,14 +19,27 @@ include_directories("${gtest_SOURCE_DIR}/include")
 
 FIND_PACKAGE(Threads REQUIRED)
 
-# from list of files we'll create tests test_name.cpp -> test_name
-function(add_unit_tests TEST_SRC_FILES TEST_LIBRARIES)
-  foreach(_test_file ${TEST_SRC_FILES})
-    get_filename_component(_test_name ${_test_file} NAME_WE)
-    add_executable(${_test_name} ${_test_file})
-    target_link_libraries(${_test_name} ${TEST_LIBRARIES} gtest_main ${CMAKE_THREAD_LIBS_INIT})
-    gtest_discover_tests(${_test_name})
-  endforeach()
+function(add_unit_tests)
+  # Parse options
+  set(_options "")
+  set(_one_value TARGET)
+  set(_multi_value SOURCES LIBRARIES)
+
+  cmake_parse_arguments(_aut "${_options}" "${_one_value}" "${_multi_value}" ${ARGN})
+
+  # Check parameters
+  if(NOT _aut_TARGET)
+    message(FATAL "No target specified to add_unit_tests")
+  endif()
+  if(NOT _aut_SOURCES)
+    message(FATAL "Must specify sources in add_unit_tests for test ${_aut_TARGET}")
+  endif()
+
+  # Create target and wire it up to ctest
+  add_executable(${_aut_TARGET} ${_aut_SOURCES})
+  target_link_libraries(${_aut_TARGET} ${_aut_LIBRARIES} gtest_main ${CMAKE_THREAD_LIBS_INIT})
+  target_include_directories(${_aut_TARGET} PUBLIC "${CMAKE_SOURCE_DIR}/src")
+  gtest_discover_tests(${_aut_TARGET})
 endfunction()
 
 ADD_SUBDIRECTORY(geometry)

--- a/unit_tests/geometry/CMakeLists.txt
+++ b/unit_tests/geometry/CMakeLists.txt
@@ -2,4 +2,4 @@ set(TEST_GEOMETRY_SRC_FILES BoundingBox.cpp)
 
 source_group(test\\geometry FILES ${TEST_GEOMETRY_SRC_FILES})
 
-add_unit_tests(${TEST_GEOMETRY_SRC_FILES} geometrylib)
+add_unit_tests(TARGET test-boundingbox SOURCES ${TEST_GEOMETRY_SRC_FILES} LIBRARIES geometrylib)


### PR DESCRIPTION
This PR adds documentation for writing Unit Tests.

It also cleans up the CMakeLists.txt structure to make writing unit tests against current CovidSim sources simpler.