### PR TITLE
Resolve many VS warnings including mystery 'k'

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -100,4 +100,9 @@ const int HOTELS_PER_1000PASSENGER = 10;
 
 const int MAX_NUM_INTERVENTION_CHANGE_TIMES = 100; // may want to make this intervention-specifc, but keep simple for now.
 
+// MS generates a lot of C26451 overflow warnings. Below is shorthand
+// to increase the cast size and clean them up.
+
+#define _I64(x) static_cast<int64_t>(x)
+
 #endif // COVIDSIM_CONSTANTS_H_INCLUDED_

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -460,11 +460,11 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 	if (P.FitIter == 0)
 	{
 		for (i = 0; i < MAX_COUNTRIES; i++) {
-			CountryNames[i] = CountryNameBuf + _I64(128) * i;
+			CountryNames[i] = CountryNameBuf + INT64_C(128) * i;
 			CountryNames[i][0] = 0;
 		}
 		for (i = 0; i < MAX_ADUNITS; i++) {
-			AdunitListNames[i] = AdunitListNamesBuf + _I64(128) * i;
+			AdunitListNames[i] = AdunitListNamesBuf + INT64_C(128) * i;
 			AdunitListNames[i][0] = 0;
 		}
 		for (i = 0; i < 100; i++) P.clP_copies[i] = 0;
@@ -554,7 +554,7 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 			P.HouseholdSizeDistrib[0][i] = P.HouseholdSizeDistrib[0][i] + P.HouseholdSizeDistrib[0][i - 1];
 		P.HouseholdDenomLookup[0] = 1.0;
 		for (i = 1; i < MAX_HOUSEHOLD_SIZE; i++)
-		    P.HouseholdDenomLookup[i] = 1 / pow(((double)(_I64(1) + i)), P.HouseholdTransPow);
+		    P.HouseholdDenomLookup[i] = 1 / pow(((double)(INT64_C(1) + i)), P.HouseholdTransPow);
 		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Include administrative units within countries", "%i", (void*)&(P.DoAdUnits), 1, 1, 0)) P.DoAdUnits = 1;
 		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Divisor for countries", "%i", (void*)&(P.CountryDivisor), 1, 1, 0)) P.CountryDivisor = 1;
 		if (P.DoAdUnits)
@@ -566,9 +566,9 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 			for (i = 0; i < ADUNIT_LOOKUP_SIZE; i++)
 			{
 				P.AdunitLevel1Lookup[i] = -1;
-				AdunitNames[3 * i] = AdunitNamesBuf + _I64(3) * i * 360;
-				AdunitNames[3 * i + 1] = AdunitNamesBuf + _I64(3) * i * 360 + 60;
-				AdunitNames[3 * i + 2] = AdunitNamesBuf + _I64(3) * i * 360 + 160;
+				AdunitNames[3 * i] = AdunitNamesBuf + INT64_C(3) * i * 360;
+				AdunitNames[3 * i + 1] = AdunitNamesBuf + INT64_C(3) * i * 360 + 60;
+				AdunitNames[3 * i + 2] = AdunitNamesBuf + INT64_C(3) * i * 360 + 160;
 			}
 			if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Divisor for level 1 administrative units", "%i", (void*)&(P.AdunitLevel1Divisor), 1, 1, 0)) P.AdunitLevel1Divisor = 1;
 			if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Mask for level 1 administrative units", "%i", (void*)&(P.AdunitLevel1Mask), 1, 1, 0)) P.AdunitLevel1Mask = 1000000000;

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
 		parse_read_file(input.substr(sep + 1), snapshot_save_file);
 	};
 
-	int cl = clock();
+	double cl = (double) clock();
 
 	// Default bitmap format is platform dependent.
 #if defined(IMAGE_MAGICK) || defined(_WIN32)
@@ -289,7 +289,7 @@ int main(int argc, char* argv[])
 	for (auto const& int_file : InterventionFiles)
 		ReadInterventions(int_file);
 
-	fprintf(stderr, "Model setup in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
+	fprintf(stderr, "Model setup in %lf seconds\n", ((double) clock() - cl) / CLOCKS_PER_SEC);
 
 
 
@@ -411,7 +411,7 @@ int main(int argc, char* argv[])
 			Bitmap_Finalise();
 
 			fprintf(stderr, "Extinction in %i out of %i runs\n", P.NRactE, P.NRactNE + P.NRactE);
-			fprintf(stderr, "Model ran in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
+			fprintf(stderr, "Model ran in %lf seconds\n", ((double)clock() - cl) / CLOCKS_PER_SEC);
 			fprintf(stderr, "Model finished\n");
 		}
 	}
@@ -460,11 +460,11 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 	if (P.FitIter == 0)
 	{
 		for (i = 0; i < MAX_COUNTRIES; i++) {
-			CountryNames[i] = CountryNameBuf + 128 * i;
+			CountryNames[i] = CountryNameBuf + _I64(128) * i;
 			CountryNames[i][0] = 0;
 		}
 		for (i = 0; i < MAX_ADUNITS; i++) {
-			AdunitListNames[i] = AdunitListNamesBuf + 128 * i;
+			AdunitListNames[i] = AdunitListNamesBuf + _I64(128) * i;
 			AdunitListNames[i][0] = 0;
 		}
 		for (i = 0; i < 100; i++) P.clP_copies[i] = 0;
@@ -554,7 +554,7 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 			P.HouseholdSizeDistrib[0][i] = P.HouseholdSizeDistrib[0][i] + P.HouseholdSizeDistrib[0][i - 1];
 		P.HouseholdDenomLookup[0] = 1.0;
 		for (i = 1; i < MAX_HOUSEHOLD_SIZE; i++)
-		    P.HouseholdDenomLookup[i] = 1 / pow(((double)(i + 1)), P.HouseholdTransPow);
+		    P.HouseholdDenomLookup[i] = 1 / pow(((double)(_I64(1) + i)), P.HouseholdTransPow);
 		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Include administrative units within countries", "%i", (void*)&(P.DoAdUnits), 1, 1, 0)) P.DoAdUnits = 1;
 		if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Divisor for countries", "%i", (void*)&(P.CountryDivisor), 1, 1, 0)) P.CountryDivisor = 1;
 		if (P.DoAdUnits)
@@ -566,9 +566,9 @@ void ReadParams(std::string const& ParamFile, std::string const& PreParamFile, s
 			for (i = 0; i < ADUNIT_LOOKUP_SIZE; i++)
 			{
 				P.AdunitLevel1Lookup[i] = -1;
-				AdunitNames[3 * i] = AdunitNamesBuf + 3 * i * 360;
-				AdunitNames[3 * i + 1] = AdunitNamesBuf + 3 * i * 360 + 60;
-				AdunitNames[3 * i + 2] = AdunitNamesBuf + 3 * i * 360 + 160;
+				AdunitNames[3 * i] = AdunitNamesBuf + _I64(3) * i * 360;
+				AdunitNames[3 * i + 1] = AdunitNamesBuf + _I64(3) * i * 360 + 60;
+				AdunitNames[3 * i + 2] = AdunitNamesBuf + _I64(3) * i * 360 + 160;
 			}
 			if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Divisor for level 1 administrative units", "%i", (void*)&(P.AdunitLevel1Divisor), 1, 1, 0)) P.AdunitLevel1Divisor = 1;
 			if (!GetInputParameter2(PreParamFile_dat, AdminFile_dat, "Mask for level 1 administrative units", "%i", (void*)&(P.AdunitLevel1Mask), 1, 1, 0)) P.AdunitLevel1Mask = 1000000000;
@@ -2361,7 +2361,7 @@ void ReadAirTravel(std::string const& air_travel_file, std::string const& output
 	sc = (float)((double)P.PopSize / (double)P.Air_popscale);
 	if (P.Nairports > MAX_AIRPORTS) ERR_CRITICAL("Too many airports\n");
 	if (P.Nairports < 2) ERR_CRITICAL("Too few airports\n");
-	buf = (float*)Memory::xcalloc(P.Nairports + 1, sizeof(float));
+	buf = (float*)Memory::xcalloc(_I64(P.Nairports) + 1, sizeof(float));
 	Airports = (Airport*)Memory::xcalloc(P.Nairports, sizeof(Airport));
 	for (i = 0; i < P.Nairports; i++)
 	{
@@ -2479,7 +2479,7 @@ void ReadAirTravel(std::string const& air_travel_file, std::string const& output
 				l = (int)traf;
 				//fprintf(stderr,"%(%i) ",l);
 				if (l < MAX_DIST)
-					AirTravelDist[l] += Airports[i].total_traffic * Airports[i].prop_traffic[j];
+					AirTravelDist[l] += (double) Airports[i].total_traffic * Airports[i].prop_traffic[j];
 			}
 		}
 	outname = output_file_base + ".airdist.xls";
@@ -3600,7 +3600,7 @@ void SaveSummaryResults(std::string const& output_file_base) //// calculates and
 	FILE* dat;
 	std::string outname;
 
-	c = 1 / ((double)(P.NRactE + P.NRactNE));
+	c = 1 / ((double)(_I64(P.NRactE) + P.NRactNE));
 
 	if (P.OutputNonSeverity)
 	{
@@ -4761,24 +4761,24 @@ void RecordSample(double t, int n, std::string const& output_file_base)
 	TimeSeries[n].I = (double)I;
 	TimeSeries[n].R = (double)R;
 	TimeSeries[n].D = (double)D;
-	TimeSeries[n].incI = (double)(cumI - State.cumI);
-	TimeSeries[n].incC = (double)(cumC - State.cumC);
-	TimeSeries[n].incFC = (double)(cumFC - State.cumFC);
-	TimeSeries[n].incCT = (double)(cumCT - State.cumCT); // added contact tracing
-	TimeSeries[n].incCC = (double)(cumCC - State.cumCC); // added cases who are contacts
-	TimeSeries[n].incDCT = (double)(cumDCT - State.cumDCT); //added cases who are digitally contact traced
-	TimeSeries[n].incDC = (double)(cumDC - State.cumDC); //added incidence of detected cases
-	TimeSeries[n].incTC = (double)(cumTC - State.cumTC);
-	TimeSeries[n].incR = (double)(cumR - State.cumR);
-	TimeSeries[n].incD = (double)(cumD - State.cumD);
-	TimeSeries[n].incHQ = (double)(cumHQ - State.cumHQ);
-	TimeSeries[n].incAC = (double)(cumAC - State.cumAC);
-	TimeSeries[n].incAH = (double)(cumAH - State.cumAH);
-	TimeSeries[n].incAA = (double)(cumAA - State.cumAA);
-	TimeSeries[n].incACS = (double)(cumACS - State.cumACS);
-	TimeSeries[n].incAPC = (double)(cumAPC - State.cumAPC);
-	TimeSeries[n].incAPA = (double)(cumAPA - State.cumAPA);
-	TimeSeries[n].incAPCS = (double)(cumAPCS - State.cumAPCS);
+	TimeSeries[n].incI = (double)(_I64(cumI) - State.cumI);
+	TimeSeries[n].incC = (double)(_I64(cumC) - State.cumC);
+	TimeSeries[n].incFC = (double)(_I64(cumFC) - State.cumFC);
+	TimeSeries[n].incCT = (double)(_I64(cumCT) - State.cumCT); // added contact tracing
+	TimeSeries[n].incCC = (double)(_I64(cumCC) - State.cumCC); // added cases who are contacts
+	TimeSeries[n].incDCT = (double)(_I64(cumDCT) - State.cumDCT); //added cases who are digitally contact traced
+	TimeSeries[n].incDC = (double)(_I64(cumDC) - State.cumDC); //added incidence of detected cases
+	TimeSeries[n].incTC = (double)(_I64(cumTC) - State.cumTC);
+	TimeSeries[n].incR = (double)(_I64(cumR) - State.cumR);
+	TimeSeries[n].incD = (double)(_I64(cumD) - State.cumD);
+	TimeSeries[n].incHQ = (double)(_I64(cumHQ) - State.cumHQ);
+	TimeSeries[n].incAC = (double)(_I64(cumAC) - State.cumAC);
+	TimeSeries[n].incAH = (double)(_I64(cumAH) - State.cumAH);
+	TimeSeries[n].incAA = (double)(_I64(cumAA) - State.cumAA);
+	TimeSeries[n].incACS = (double)(_I64(cumACS) - State.cumACS);
+	TimeSeries[n].incAPC = (double)(_I64(cumAPC) - State.cumAPC);
+	TimeSeries[n].incAPA = (double)(_I64(cumAPA) - State.cumAPA);
+	TimeSeries[n].incAPCS = (double)(_I64(cumAPCS) - State.cumAPCS);
 	TimeSeries[n].cumT = State.cumT;
 	TimeSeries[n].cumUT = State.cumUT;
 	TimeSeries[n].cumTP = State.cumTP;
@@ -4793,7 +4793,7 @@ void RecordSample(double t, int n, std::string const& output_file_base)
 	}
 	//fprintf(stderr, "\ncumD=%i last_cumD=%i incD=%lg\n ", cumD, State.cumD, TimeSeries[n].incD);
 	//incidence per country
-	for (int i = 0; i < MAX_COUNTRIES; i++) TimeSeries[n].incC_country[i] = (double)(cumC_country[i] - State.cumC_country[i]);
+	for (int i = 0; i < MAX_COUNTRIES; i++) TimeSeries[n].incC_country[i] = (double)(_I64(cumC_country[i]) - State.cumC_country[i]);
 	if (P.DoICUTriggers)
 	{
 		trigDetectedCases = cumCritical;
@@ -4841,14 +4841,14 @@ void RecordSample(double t, int n, std::string const& output_file_base)
 	{
 
 		//// Record incidence. (Must be done with old State totals)
-		TimeSeries[n].incMild = (double)(cumMild - State.cumMild);
-		TimeSeries[n].incILI = (double)(cumILI - State.cumILI);
-		TimeSeries[n].incSARI = (double)(cumSARI - State.cumSARI);
-		TimeSeries[n].incCritical = (double)(cumCritical - State.cumCritical);
-		TimeSeries[n].incCritRecov = (double)(cumCritRecov - State.cumCritRecov);
-		TimeSeries[n].incDeath_ILI = (double)(cumDeath_ILI - State.cumDeath_ILI);
-		TimeSeries[n].incDeath_SARI = (double)(cumDeath_SARI - State.cumDeath_SARI);
-		TimeSeries[n].incDeath_Critical = (double)(cumDeath_Critical - State.cumDeath_Critical);
+		TimeSeries[n].incMild = (double)(_I64(cumMild) - State.cumMild);
+		TimeSeries[n].incILI = (double)(_I64(cumILI) - State.cumILI);
+		TimeSeries[n].incSARI = (double)(_I64(cumSARI) - State.cumSARI);
+		TimeSeries[n].incCritical = (double)(_I64(cumCritical) - State.cumCritical);
+		TimeSeries[n].incCritRecov = (double)(_I64(cumCritRecov) - State.cumCritRecov);
+		TimeSeries[n].incDeath_ILI = (double)(_I64(cumDeath_ILI) - State.cumDeath_ILI);
+		TimeSeries[n].incDeath_SARI = (double)(_I64(cumDeath_SARI) - State.cumDeath_SARI);
+		TimeSeries[n].incDeath_Critical = (double)(_I64(cumDeath_Critical) - State.cumDeath_Critical);
 
 		/////// update state with totals
 		State.Mild = Mild;
@@ -5446,7 +5446,7 @@ void CalcLikelihood(int run, std::string const& DataFile, std::string const& Out
 					double ModelValue;
 					for (int k = offset; k < day; k++) // loop over all days of infection up to day of sample
 					{
-						double prob_seroconvert = P.SeroConvMaxSens*(1.0-0.5*((exp(-((double)(day - k))*P.SeroConvP1) + 1.0)*exp(-((double)(day - k))*P.SeroConvP2))); // add P1 to P2 to prevent degeneracy
+						double prob_seroconvert = P.SeroConvMaxSens*(1.0-0.5*((exp(-((double)(_I64(day) - k))*P.SeroConvP1) + 1.0)*exp(-((double)(_I64(day) - k))*P.SeroConvP2))); // add P1 to P2 to prevent degeneracy
 						ModelValue += c * TimeSeries[k - offset].incI * prob_seroconvert;
 					}
 					ModelValue += c * TimeSeries[day-offset].S * (1.0 - P.SeroConvSpec);
@@ -5496,7 +5496,7 @@ void RecordInfTypes(void)
 {
 	int i, j, k, l, lc, lc2, b, c, n, i2;
 	unsigned int nf;
-	double* res, * res_av, * res_var, t, s;
+	double* res, * res_av, * res_var, t, s = 0;
 
 	for (n = 0; n < P.NumSamples; n++)
 	{
@@ -5627,7 +5627,7 @@ void RecordInfTypes(void)
 	{
 		if ((n + lc >= 0) && (n + lc < P.NumSamples))
 		{
-			if (s < TimeSeries[n + lc].incC) { s = TimeSeries[n + lc].incC; t = P.SampleStep * ((double)(n + lc)); }
+			if (s < TimeSeries[n + lc].incC) { s = TimeSeries[n + lc].incC; t = P.SampleStep * ((double)(_I64(n) + lc)); }
 			res = (double*)&TimeSeries[n + lc];
 			res_av = (double*)&TSMean[n];
 			res_var = (double*)&TSVar[n];
@@ -5689,7 +5689,7 @@ void CalcOriginDestMatrix_adunit()
 				for (int l = 0; l < P.NMCL; l++)
 				{
 					//get index of microcell
-					ptrdiff_t mcl_from = cl_from_mcl + l + k * P.total_microcells_high_;
+					ptrdiff_t mcl_from = cl_from_mcl + l + _I64(k) * P.total_microcells_high_;
 					if (Mcells[mcl_from].n > 0)
 					{
 						//get proportion of each population of cell that exists in each admin unit
@@ -5711,11 +5711,11 @@ void CalcOriginDestMatrix_adunit()
 				double total_flow;
 				if (j == 0)
 				{
-					total_flow = Cells[cl_from].cum_trans[j] * Cells[cl_from].n;
+					total_flow = (double)Cells[cl_from].cum_trans[j] * Cells[cl_from].n;
 				}
 				else
 				{
-					total_flow = (Cells[cl_from].cum_trans[j] - Cells[cl_from].cum_trans[j - 1]) * Cells[cl_from].n;
+					total_flow = ((double)Cells[cl_from].cum_trans[j] - Cells[cl_from].cum_trans[j - 1]) * Cells[cl_from].n;
 				}
 
 				//loop over microcells within destination cell
@@ -5724,7 +5724,7 @@ void CalcOriginDestMatrix_adunit()
 					for (int p = 0; p < P.NMCL; p++)
 					{
 						//get index of microcell
-						ptrdiff_t mcl_to = cl_to_mcl + p + m * P.total_microcells_high_;
+						ptrdiff_t mcl_to = cl_to_mcl + p + _I64(m) * P.total_microcells_high_;
 						if (Mcells[mcl_to].n > 0)
 						{
 							//get proportion of each population of cell that exists in each admin unit

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -1280,7 +1280,7 @@ void SetupPopulation(std::string const& density_file, std::string const& out_den
 		}
 
 		// make age adjustments to population
-#pragma omp parallel for private(j,k,m,s) schedule(static,1) default(none) \
+#pragma omp parallel for private(j,m,s) schedule(static,1) default(none) \
 			shared(P, Hosts, AgeDistCorrF, AgeDistCorrB, Mcells, reg_demog_file)
 		for (int tn = 0; tn < P.NumThreads; tn++)
 			for (int i = tn; i < P.PopSize; i += P.NumThreads)

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -540,7 +540,7 @@ void SetupModel(std::string const& density_file, std::string const& out_density_
 			}
 			for (int j = vaccineCount; j < State.n_mvacc; j++)
 			{
-				l = vaccineCount + ((int)(ranf() * ((double)(State.n_mvacc - vaccineCount))));
+				l = vaccineCount + ((int)(ranf() * ((double)(_I64(State.n_mvacc) - vaccineCount))));
 				m = State.mvacc_queue[j];
 				State.mvacc_queue[j] = State.mvacc_queue[l];
 				State.mvacc_queue[l] = m;
@@ -622,7 +622,7 @@ void InitTransmissionCoeffs(void)
 	t = s = t2 = 0;
 	for (int i = 0; i < MAX_HOUSEHOLD_SIZE; i++)
 	{
-		t += ((double)(i + 1)) * (P.HouseholdSizeDistrib[0][i] - t2);
+		t += ((double)(_I64(1) + i)) * (P.HouseholdSizeDistrib[0][i] - t2);
 		t2 = P.HouseholdSizeDistrib[0][i];
 	}
 	fprintf(stderr, "Household mean size=%lg\n", t);
@@ -707,7 +707,7 @@ void InitTransmissionCoeffs(void)
 							double y = 1.0 - x * P.infectiousness[m];
 							d *= ((y < 0) ? 0 : y);
 						}
-						s3 = ((double)(Places[j][k].group_size[Hosts[i].PlaceGroupLinks[j]] - 1));
+						s3 = ((double)(_I64(Places[j][k].group_size[Hosts[i].PlaceGroupLinks[j]]) - 1));
 						x *= (((Hosts[i].infectiousness < 0) && (!Hosts[i].care_home_resident)) ? (P.SymptPlaceTypeContactRate[j] * (1 - P.SymptPlaceTypeWithdrawalProp[j])) : 1);
 						l = (int)Hosts[i].recovery_or_death_time;
 						for (; m < l; m++) {
@@ -732,7 +732,7 @@ void InitTransmissionCoeffs(void)
 							double y = 1.0 - x * P.infectiousness[m];
 							d *= ((y < 0) ? 0 : y);
 						}
-						t += (1 - t3 * d) * s3 + (1 - d) * (((double)(Places[j][k].n - 1)) - s3);
+						t += (1 - t3 * d) * s3 + (1 - d) * (((double)(_I64(Places[j][k].n) - 1)) - s3);
 					}
 				}
 				fprintf(stderr, "%lg  ", (t-tpl) / ((double)P.PopSize));
@@ -1517,7 +1517,7 @@ void SetupPopulation(std::string const& density_file, std::string const& out_den
 		SamplingQueue[i] = (int*)Memory::xcalloc(2 * (MAX_PLACE_SIZE + CACHE_LINE_SIZE), sizeof(int));
 		for (int k = 0; k < P.NumThreads; k++)
 			StateT[i].inf_queue[k] = (Infection*)Memory::xcalloc(P.InfQueuePeakLength, sizeof(Infection));
-		StateT[i].cell_inf = (float*)Memory::xcalloc(l + 1, sizeof(float));
+		StateT[i].cell_inf = (float*)Memory::xcalloc(_I64(1) + l, sizeof(float));
 		StateT[i].host_closure_queue = (HostClosure*)Memory::xcalloc(P.InfQueuePeakLength, sizeof(HostClosure));
 	}
 
@@ -1579,8 +1579,8 @@ void SetupAirports(void)
 	P.Kernel = P.AirportKernel;
 	P.KernelLookup.init(1.0, P.Kernel);
 	CovidSim::TBD1::KernelLookup::init(P.KernelLookup, CellLookup, P.NCP);
-	Airports[0].DestMcells = (IndexList*)Memory::xcalloc(P.NMCP * NNA, sizeof(IndexList));
-	base = (IndexList*)Memory::xcalloc(P.NMCP * NNA, sizeof(IndexList));
+	Airports[0].DestMcells = (IndexList*)Memory::xcalloc(_I64(P.NMCP) * NNA, sizeof(IndexList));
+	base = (IndexList*)Memory::xcalloc(_I64(P.NMCP) * NNA, sizeof(IndexList));
 	for (int i = 0; i < P.Nairports; i++) Airports[i].num_mcell = 0;
 	cur = base;
 	for (int i = 0; i < P.NMC; i++)
@@ -1773,7 +1773,7 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 					a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				}
 				while ((a[0] < P.NoChildPersAge)
-					|| (ranf_mt(tn) > (((double)a[0]) - P.NoChildPersAge + 1) / (P.OldPersAge - P.NoChildPersAge + 1)));
+					|| (ranf_mt(tn) > (((double)a[0]) - P.NoChildPersAge + 1) / (_I64(P.OldPersAge) - P.NoChildPersAge + 1)));
 			}
 			else if ((P.OnePersHouseProbYoung > 0) && (ranf_mt(tn) < P.OnePersHouseProbYoung / (1 - P.OnePersHouseProbOld)))
 			{
@@ -1781,7 +1781,7 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 				{
 					a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				} while ((a[0] > P.YoungAndSingle) || (a[0] < P.MinAdultAge)
-					|| (ranf_mt(tn) > 1 - P.YoungAndSingleSlope * (((double)a[0]) - P.MinAdultAge) / (P.YoungAndSingle - P.MinAdultAge)));
+					|| (ranf_mt(tn) > 1 - P.YoungAndSingleSlope * (((double)a[0]) - P.MinAdultAge) / (_I64(P.YoungAndSingle) - P.MinAdultAge)));
 			}
 			else
 				while ((a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))]) < P.MinAdultAge);
@@ -1795,13 +1795,13 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 					a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				}
 				while ((a[0] < P.NoChildPersAge)
-					|| (ranf_mt(tn) > (((double)a[0]) - P.NoChildPersAge + 1) / (P.OldPersAge - P.NoChildPersAge + 1)));
+					|| (ranf_mt(tn) > (((double)a[0]) - P.NoChildPersAge + 1) / (_I64(P.OldPersAge) - P.NoChildPersAge + 1)));
 				do
 				{
 					a[1] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				}
 				while ((a[1] > a[0] + P.MaxMFPartnerAgeGap) || (a[1] < a[0] - P.MaxFMPartnerAgeGap) || (a[1] < P.NoChildPersAge)
-					|| (ranf_mt(tn) > (((double)a[1]) - P.NoChildPersAge + 1) / (P.OldPersAge - P.NoChildPersAge + 1)));
+					|| (ranf_mt(tn) > (((double)a[1]) - P.NoChildPersAge + 1) / (_I64(P.OldPersAge) - P.NoChildPersAge + 1)));
 			}
 			else if (ranf_mt(tn) < P.OneChildTwoPersProb / (1 - P.TwoPersHouseProbOld))
 			{
@@ -1818,7 +1818,7 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 				{
 					a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
 				} while ((a[0] < P.MinAdultAge) || (a[0] > P.YoungAndSingle)
-					|| (ranf_mt(tn) > 1 - P.YoungAndSingleSlope * (((double)a[0]) - P.MinAdultAge) / (P.YoungAndSingle - P.MinAdultAge)));
+					|| (ranf_mt(tn) > 1 - P.YoungAndSingleSlope * (((double)a[0]) - P.MinAdultAge) / (_I64(P.YoungAndSingle) - P.MinAdultAge)));
 				do
 				{
 					a[1] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))];
@@ -1874,7 +1874,7 @@ void AssignHouseholdAges(int n, int pers, int tn, bool do_adunit_demog)
 				{
 					a[0] = 0;
 					for (i = 1; i < nc; i++)
-						a[i] = a[i - 1] + 1 + ((int)ignpoi_mt(P.MeanChildAgeGap - 1, tn));
+						a[i] = a[i - 1] + 1 + ((int)ignpoi_mt((double) (_I64(P.MeanChildAgeGap) - 1), tn));
 					a[0] = State.InvAgeDist[ad][(int)(1000.0 * ranf_mt(tn))] - a[(int)(ranf_mt(tn) * ((double)nc))];
 					for (i = 1; i < nc; i++) a[i] += a[0];
 					k = (((nc == 1) && (ranf_mt(tn) < P.OneChildProbYoungestChildUnderFive)) || ((nc == 2) && (ranf_mt(tn) < P.TwoChildrenProbYoungestUnderFive))
@@ -2158,8 +2158,8 @@ void AssignPeopleToPlaces()
 				}
 				for (int i = 0; i < P.NumThreads; i++)
 				{
-					NearestPlaces[i] = (int*)Memory::xcalloc(P.PlaceTypeNearestNeighb[tp] + CACHE_LINE_SIZE, sizeof(int));
-					NearestPlacesProb[i] = (double*)Memory::xcalloc(P.PlaceTypeNearestNeighb[tp] + CACHE_LINE_SIZE, sizeof(double));
+					NearestPlaces[i] = (int*)Memory::xcalloc(_I64(P.PlaceTypeNearestNeighb[tp]) + CACHE_LINE_SIZE, sizeof(int));
+					NearestPlacesProb[i] = (double*)Memory::xcalloc(_I64(P.PlaceTypeNearestNeighb[tp]) + CACHE_LINE_SIZE, sizeof(double));
 				}
 				P.Kernel.type_ = P.PlaceTypeKernelType[tp];
 				P.Kernel.scale_ = P.PlaceTypeKernelScale[tp];
@@ -2457,7 +2457,7 @@ void StratifyPlaces(void)
 							int l;
 							for (int k = l = 0; k < Places[j][i].ng; k++)
 							{
-								t = 1 / ((double)(Places[j][i].ng - k));
+								t = 1 / ((double)(_I64(Places[j][i].ng) - k));
 								Places[j][i].group_start[k] = l;
 								Places[j][i].group_size[k] = 1 + ignbin_mt((int32_t)m, t, tn);
 								m -= (Places[j][i].group_size[k] - 1);
@@ -2559,7 +2559,7 @@ void LoadPeopleToPlaces(std::string const& load_network_file)
 	for (i = i2 = 0; i < k; i++)
 	{
 		l = (i < k - 1) ? 1000000 : (P.PopSize - 1000000 * (k - 1));
-		fread_big(&netbuf, sizeof(int), npt * l, dat);
+		fread_big(&netbuf, sizeof(int), _I64(npt) * l, dat);
 		for (j = 0; j < l; j++)
 		{
 			n = j * npt;

--- a/src/SetupModel.cpp
+++ b/src/SetupModel.cpp
@@ -622,7 +622,7 @@ void InitTransmissionCoeffs(void)
 	t = s = t2 = 0;
 	for (int i = 0; i < MAX_HOUSEHOLD_SIZE; i++)
 	{
-		t += ((double)(_I64(1) + i)) * (P.HouseholdSizeDistrib[0][i] - t2);
+		t += ((double)(INT64_C(1) + i)) * (P.HouseholdSizeDistrib[0][i] - t2);
 		t2 = P.HouseholdSizeDistrib[0][i];
 	}
 	fprintf(stderr, "Household mean size=%lg\n", t);
@@ -1517,7 +1517,7 @@ void SetupPopulation(std::string const& density_file, std::string const& out_den
 		SamplingQueue[i] = (int*)Memory::xcalloc(2 * (MAX_PLACE_SIZE + CACHE_LINE_SIZE), sizeof(int));
 		for (int k = 0; k < P.NumThreads; k++)
 			StateT[i].inf_queue[k] = (Infection*)Memory::xcalloc(P.InfQueuePeakLength, sizeof(Infection));
-		StateT[i].cell_inf = (float*)Memory::xcalloc(_I64(1) + l, sizeof(float));
+		StateT[i].cell_inf = (float*)Memory::xcalloc(INT64_C(1) + l, sizeof(float));
 		StateT[i].host_closure_queue = (HostClosure*)Memory::xcalloc(P.InfQueuePeakLength, sizeof(HostClosure));
 	}
 


### PR DESCRIPTION
Not a very exciting PR, but this deals with all the [C26451](https://docs.microsoft.com/en-us/cpp/code-quality/c26451?view=vs-2019) warnings VS gives about potential arithmetic overflows. (I don't think we have any, but this at least clears out the noise).

More excitingly (to me), it deals with the 
`1>C:\Files\Dev\covid-sim\src\SetupModel.cpp(770): warning C4101: 'k': unreferenced local variable`

where there is clearly no reference to k on line 770
```
void SetupPopulation(std::string const& density_file, std::string const& out_density_file, std::string const& school_file, std::string const& reg_demog_file)
```

The warning actually refers to an OpenMP section where `k` is not needed and should be removed from line 1283

```
#pragma omp parallel for private(j,k,m,s) schedule(static,1) default(none) \
```
